### PR TITLE
Unify infobox: always show all time representations and simulation mode context

### DIFF
--- a/src/components/OutcomePanel.tsx
+++ b/src/components/OutcomePanel.tsx
@@ -109,6 +109,20 @@ export function OutcomePanel({
             </div>
             <div className='outcome-stats'>
               <div className='stat'>
+                <span className='stat-label'>{tr(lang, 'stats.yearsFromNow')}</span>
+                <span className='stat-value'>{p50CrossoverYear}</span>
+              </div>
+              <div className='stat'>
+                <span className='stat-label'>{tr(lang, 'stats.calendarYear')}</span>
+                <span className='stat-value'>{CURRENT_YEAR + p50CrossoverYear!}</span>
+              </div>
+              {ageYears !== null && (
+                <div className='stat'>
+                  <span className='stat-label'>{tr(lang, 'stats.ageAt')}</span>
+                  <span className='stat-value'>{ageYears + p50CrossoverYear!}</span>
+                </div>
+              )}
+              <div className='stat'>
                 <span className='stat-label'>{tr(lang, 'stats.capitalAt')}</span>
                 <span className='stat-value'>{formatMoney(mcCrossoverMcPoint?.capitalP50 ?? 0)}</span>
               </div>
@@ -146,6 +160,20 @@ export function OutcomePanel({
               </div>
             </div>
             <div className='outcome-stats'>
+              <div className='stat'>
+                <span className='stat-label'>{tr(lang, 'stats.yearsFromNow')}</span>
+                <span className='stat-value'>{mcFinalPoint?.year}</span>
+              </div>
+              <div className='stat'>
+                <span className='stat-label'>{tr(lang, 'stats.calendarYear')}</span>
+                <span className='stat-value'>{mcFinalPoint ? CURRENT_YEAR + mcFinalPoint.year : '—'}</span>
+              </div>
+              {ageYears !== null && mcFinalPoint && (
+                <div className='stat'>
+                  <span className='stat-label'>{tr(lang, 'stats.ageAt')}</span>
+                  <span className='stat-value'>{ageYears + mcFinalPoint.year}</span>
+                </div>
+              )}
               <div className='stat'>
                 <span className='stat-label'>{tr(lang, 'stats.finalCapital')}</span>
                 <span className='stat-value'>{formatMoney(mcFinalPoint?.capitalP50 ?? 0)}</span>
@@ -222,6 +250,20 @@ export function OutcomePanel({
           </div>
           <div className='outcome-stats'>
             <div className='stat'>
+              <span className='stat-label'>{tr(lang, 'stats.yearsFromNow')}</span>
+              <span className='stat-value'>{crossoverPoint.year}</span>
+            </div>
+            <div className='stat'>
+              <span className='stat-label'>{tr(lang, 'stats.calendarYear')}</span>
+              <span className='stat-value'>{CURRENT_YEAR + crossoverPoint.year}</span>
+            </div>
+            {ageYears !== null && (
+              <div className='stat'>
+                <span className='stat-label'>{tr(lang, 'stats.ageAt')}</span>
+                <span className='stat-value'>{ageYears + crossoverPoint.year}</span>
+              </div>
+            )}
+            <div className='stat'>
               <span className='stat-label'>{tr(lang, 'stats.capitalAt')}</span>
               <span className='stat-value'>{formatMoney(crossoverPoint.capital)}</span>
             </div>
@@ -239,12 +281,6 @@ export function OutcomePanel({
                 <span className='stat-unit'>{py}</span>
               </span>
             </div>
-            {ageYears !== null ? (
-              <div className='stat'>
-                <span className='stat-label'>{tr(lang, 'stats.ageAt')}</span>
-                <span className='stat-value'>{ageYears + crossoverPoint.year}</span>
-              </div>
-            ) : null}
           </div>
           <p className='outcome-note'>
             {trParams(lang, 'result.outcome.crossoverSurplus', {
@@ -265,6 +301,20 @@ export function OutcomePanel({
           </div>
           <div className='outcome-stats'>
             <div className='stat'>
+              <span className='stat-label'>{tr(lang, 'stats.yearsFromNow')}</span>
+              <span className='stat-value'>{finalPoint.year}</span>
+            </div>
+            <div className='stat'>
+              <span className='stat-label'>{tr(lang, 'stats.calendarYear')}</span>
+              <span className='stat-value'>{CURRENT_YEAR + finalPoint.year}</span>
+            </div>
+            {ageYears !== null && (
+              <div className='stat'>
+                <span className='stat-label'>{tr(lang, 'stats.ageAt')}</span>
+                <span className='stat-value'>{ageYears + finalPoint.year}</span>
+              </div>
+            )}
+            <div className='stat'>
               <span className='stat-label'>{tr(lang, 'stats.finalCapital')}</span>
               <span className='stat-value'>{formatMoney(finalPoint.capital)}</span>
             </div>
@@ -282,12 +332,6 @@ export function OutcomePanel({
                 <span className='stat-unit'>{py}</span>
               </span>
             </div>
-            {ageYears !== null ? (
-              <div className='stat'>
-                <span className='stat-label'>{tr(lang, 'stats.ageAt')}</span>
-                <span className='stat-value'>{ageYears + finalPoint.year}</span>
-              </div>
-            ) : null}
           </div>
           <p className='outcome-note outcome-note--warn'>
             {trParams(lang, 'result.outcome.noCrossoverGap', {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -112,7 +112,9 @@
     "finalCapital": "Capital at end",
     "maxIncome": "Max. annual return",
     "finalCost": "Expenses at end",
-    "ageAt": "Age then"
+    "ageAt": "Age then",
+    "yearsFromNow": "Years from now",
+    "calendarYear": "Calendar year"
   },
   "units": {
     "perYear": "/yr."

--- a/src/i18n/sr.json
+++ b/src/i18n/sr.json
@@ -112,7 +112,9 @@
     "finalCapital": "Kapital na kraju",
     "maxIncome": "Maks. godišnji prinos",
     "finalCost": "Troškovi na kraju",
-    "ageAt": "Starost tada"
+    "ageAt": "Starost tada",
+    "yearsFromNow": "Za koliko godina",
+    "calendarYear": "Kalendarska godina"
   },
   "units": {
     "perYear": "/god."


### PR DESCRIPTION
Closes #5

## Summary
- Stats block now always shows **Years from now** (relative) and **Calendar year** (absolute) regardless of which X-axis mode is active — applies to all four cases: deterministic crossover, deterministic no-crossover, MC crossover, MC no-crossover
- **Age at crossover/end** stat now shown in MC sections too, whenever `currentAge` is provided
- Time stats are rendered before financial stats in each block
- MC mode note ("Monte Carlo · N runs · p10–p90 band") and historical data mode note were already implemented; no changes needed there
- Added `stats.yearsFromNow` and `stats.calendarYear` i18n keys to both `en.json` and `sr.json`

## Acceptance criteria
- [x] Stats block always includes the relative-year crossover stat
- [x] Stats block always includes the calendar-year crossover stat (independent of X-axis mode)
- [x] Stats block includes age-at-crossover whenever `currentAge` is provided, regardless of X-axis mode
- [x] Same three representations shown in the no-crossover final-state view
- [x] When Monte Carlo mode is active, result note shows mode + run count + percentile
- [x] When historical data mode is active, result note shows mode + data start year
- [x] Both languages (sr/en) updated with new label keys

## Test plan
- [ ] Fixed mode with age set: verify stats block shows years from now, calendar year, and age — in both crossover and no-crossover cases
- [ ] Fixed mode without age: verify only years from now and calendar year appear
- [ ] Switch X-axis between rel/cal/age: verify stats block stays identical across all three modes
- [ ] MC mode with age set, crossover found: verify all three time stats + success rate
- [ ] MC mode, no crossover: verify all three time stats at horizon end + success rate
- [ ] Historical mode: verify mode note appears with start and end year
- [ ] Toggle language SR ↔ EN: verify new labels appear correctly in both

🤖 Generated with [Claude Code](https://claude.com/claude-code)