### PR TITLE
Add optional asset class allocations (issue #14)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -135,7 +135,7 @@
 /* ── Form grid ── */
 
 .form-grid {
-  --field-control-w: 8.75rem;
+  --field-control-w: 7rem;
 
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
@@ -456,6 +456,15 @@
   font-weight: 400;
   margin-top: 0.15rem;
   opacity: 0.85;
+}
+
+.field-sub-label {
+  display: block;
+  font-size: 0.72rem;
+  color: var(--text);
+  font-weight: 400;
+  margin-top: 0.4rem;
+  opacity: 0.75;
 }
 
 /* ── Monte Carlo section ── */
@@ -925,22 +934,39 @@
   gap: 0.75rem;
 }
 
-/* Asset row */
-.alloc-asset-row {
+/* Asset grid */
+.alloc-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.5rem;
+}
+
+@media (max-width: 560px) {
+  .alloc-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Asset card */
+.alloc-card {
   border: 1px solid var(--border);
   border-radius: 6px;
   padding: 0.5rem 0.75rem;
   transition: background 0.1s;
 }
 
-.alloc-asset-row--on {
+.alloc-card--on {
   background: color-mix(in srgb, var(--panel-bg) 90%, var(--chart-capital) 10%);
 }
 
-.alloc-asset-row--stocks {
-  background: color-mix(in srgb, var(--panel-bg) 90%, var(--chart-capital) 10%);
+.alloc-card-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-height: 28px;
 }
 
+/* Keep old alloc-asset-row for any backward compat (not used in grid layout) */
 .alloc-asset-header {
   display: flex;
   align-items: center;
@@ -1024,7 +1050,7 @@
 
 .alloc-field input[type='text'] {
   width: 100%;
-  max-width: 10rem;
+  max-width: 100%;
   padding: 0.3rem 0.5rem;
   border: 1px solid var(--border);
   border-radius: 4px;
@@ -1035,7 +1061,7 @@
 
 .alloc-field input[type='range'] {
   width: 100%;
-  max-width: 14rem;
+  max-width: 100%;
   margin-top: 0.1rem;
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -1202,3 +1202,18 @@ details[open] .alloc-section-summary::before { transform: rotate(90deg); }
   cursor: default;
   background: color-mix(in srgb, var(--panel-bg) 80%, var(--border) 20%);
 }
+
+.alloc-bar-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.alloc-bar-title {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--text);
+  opacity: 0.65;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -898,23 +898,11 @@
   align-items: center;
   gap: 0.5rem;
   padding: 0.65rem 1rem;
-  cursor: pointer;
   font-size: 0.85rem;
   font-weight: 600;
   color: var(--text);
-  user-select: none;
-  list-style: none;
+  border-bottom: 1px solid var(--border);
 }
-
-.alloc-section-summary::-webkit-details-marker { display: none; }
-.alloc-section-summary::before {
-  content: '▶';
-  font-size: 0.65rem;
-  transition: transform 0.15s;
-  color: var(--text);
-  opacity: 0.5;
-}
-details[open] .alloc-section-summary::before { transform: rotate(90deg); }
 
 .alloc-section-badge {
   display: inline-flex;

--- a/src/App.css
+++ b/src/App.css
@@ -883,3 +883,322 @@
   color: var(--text);
   opacity: 0.92;
 }
+
+/* ── Asset Allocation Section ── */
+
+.alloc-section {
+  margin-top: 1rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.alloc-section-summary {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.65rem 1rem;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text);
+  user-select: none;
+  list-style: none;
+}
+
+.alloc-section-summary::-webkit-details-marker { display: none; }
+.alloc-section-summary::before {
+  content: '▶';
+  font-size: 0.65rem;
+  transition: transform 0.15s;
+  color: var(--text);
+  opacity: 0.5;
+}
+details[open] .alloc-section-summary::before { transform: rotate(90deg); }
+
+.alloc-section-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 4px;
+  border-radius: 9px;
+  background: var(--chart-capital);
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+.alloc-body {
+  padding: 0.75rem 1rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+/* Asset row */
+.alloc-asset-row {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.5rem 0.75rem;
+  transition: background 0.1s;
+}
+
+.alloc-asset-row--on {
+  background: color-mix(in srgb, var(--panel-bg) 90%, var(--chart-capital) 10%);
+}
+
+.alloc-asset-row--stocks {
+  background: color-mix(in srgb, var(--panel-bg) 90%, var(--chart-capital) 10%);
+}
+
+.alloc-asset-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-height: 28px;
+}
+
+.alloc-asset-swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.alloc-asset-name {
+  font-size: 0.82rem;
+  font-weight: 600;
+  flex: 1;
+}
+
+.alloc-toggle-label {
+  font-size: 0.82rem;
+  font-weight: 600;
+  flex: 1;
+  cursor: pointer;
+}
+
+/* Toggle switch */
+.alloc-toggle {
+  position: relative;
+  width: 36px;
+  height: 20px;
+  border-radius: 10px;
+  border: none;
+  cursor: pointer;
+  background: var(--border);
+  transition: background 0.2s;
+  flex-shrink: 0;
+  padding: 0;
+}
+
+.alloc-toggle--on {
+  background: var(--chart-capital);
+}
+
+.alloc-toggle-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+  transition: transform 0.2s;
+}
+
+.alloc-toggle--on .alloc-toggle-thumb {
+  transform: translateX(16px);
+}
+
+/* Asset input fields */
+.alloc-asset-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.alloc-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.alloc-field-label {
+  font-size: 0.72rem;
+  color: var(--text);
+  opacity: 0.7;
+}
+
+.alloc-field input[type='text'] {
+  width: 100%;
+  max-width: 10rem;
+  padding: 0.3rem 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 0.82rem;
+  background: var(--input-bg, var(--panel-bg));
+  color: var(--text);
+}
+
+.alloc-field input[type='range'] {
+  width: 100%;
+  max-width: 14rem;
+  margin-top: 0.1rem;
+}
+
+/* Blended summary */
+.alloc-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.5rem;
+  font-size: 0.78rem;
+  color: var(--text);
+  opacity: 0.85;
+  padding: 0.4rem 0;
+  border-top: 1px solid var(--border);
+}
+
+/* Notice (crypto clamp) */
+.alloc-notice {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  font-size: 0.78rem;
+  color: var(--text);
+  background: color-mix(in srgb, var(--panel-bg) 80%, orange 20%);
+  border: 1px solid color-mix(in srgb, var(--border) 70%, orange 30%);
+  border-radius: 4px;
+  padding: 0.4rem 0.6rem;
+  margin: 0;
+}
+
+.alloc-notice-close {
+  margin-left: auto;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  color: var(--text);
+  opacity: 0.6;
+  padding: 0 0.1rem;
+}
+
+/* ── Allocation Bar ── */
+
+.alloc-bar-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+}
+
+.alloc-bar {
+  display: flex;
+  width: 100%;
+  height: 36px;
+  border-radius: 6px;
+  overflow: hidden;
+  position: relative;
+}
+
+.alloc-bar-seg {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: visible;
+  transition: flex 0.1s;
+  min-width: 0;
+}
+
+.alloc-bar-label {
+  font-size: 0.68rem;
+  font-weight: 600;
+  color: rgba(0,0,0,0.75);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding: 0 4px;
+  pointer-events: none;
+}
+
+.alloc-bar-divider {
+  position: absolute;
+  right: -5px;
+  top: 0;
+  width: 10px;
+  height: 100%;
+  cursor: col-resize;
+  z-index: 2;
+  background: transparent;
+}
+
+.alloc-bar-divider::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 20%;
+  width: 2px;
+  height: 60%;
+  transform: translateX(-50%);
+  background: rgba(0,0,0,0.25);
+  border-radius: 1px;
+}
+
+/* Bar legend with reorder arrows */
+.alloc-bar-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem 0.8rem;
+}
+
+.alloc-bar-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.72rem;
+}
+
+.alloc-bar-legend-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.alloc-bar-legend-name {
+  color: var(--text);
+}
+
+.alloc-bar-legend-arrows {
+  display: flex;
+  gap: 1px;
+}
+
+.alloc-bar-arrow {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 0.7rem;
+  padding: 0 4px;
+  color: var(--text);
+  line-height: 1.5;
+}
+
+.alloc-bar-arrow:disabled {
+  opacity: 0.25;
+  cursor: default;
+}
+
+.field--readonly input {
+  opacity: 0.75;
+  cursor: default;
+  background: color-mix(in srgb, var(--panel-bg) 80%, var(--border) 20%);
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,17 +39,11 @@ export default function App() {
     typeof window !== 'undefined' ? window.matchMedia('(max-width: 560px)').matches : false,
   );
 
-  const [initialCapital, setInitialCapital] = useState(
-    () => urlInit.initialCapital ?? String(DEFAULTS.initialCapital),
-  );
   const [monthlyNeedToday, setMonthlyNeedToday] = useState(
     () => urlInit.monthlyNeedToday ?? String(DEFAULTS.monthlyNeedToday),
   );
   const [annualInflationPercent, setAnnualInflationPercent] = useState(
     () => urlInit.annualInflationPercent ?? String(DEFAULTS.annualInflationPercent),
-  );
-  const [monthlyContribution, setMonthlyContribution] = useState(
-    () => urlInit.monthlyContribution ?? String(DEFAULTS.monthlyContribution),
   );
   const [annualReturnPercent, setAnnualReturnPercent] = useState(
     () => urlInit.annualReturnPercent ?? String(DEFAULTS.annualReturnPercent),
@@ -81,10 +75,10 @@ export default function App() {
     () => urlInit.extraAssets ?? { ...EXTRA_ASSET_DEFAULTS },
   );
   const [stocksVal, setStocksVal] = useState<string>(
-    () => urlInit.stocksVal ?? String(DEFAULTS.initialCapital),
+    () => urlInit.stocksVal ?? urlInit.initialCapital ?? String(DEFAULTS.initialCapital),
   );
   const [stocksCon, setStocksCon] = useState<string>(
-    () => urlInit.stocksCon ?? String(DEFAULTS.monthlyContribution),
+    () => urlInit.stocksCon ?? urlInit.monthlyContribution ?? String(DEFAULTS.monthlyContribution),
   );
   const [allocOrder, setAllocOrder] = useState<string[]>(
     () => urlInit.allocOrder ?? [...DEFAULT_ALLOC_ORDER],
@@ -147,12 +141,6 @@ export default function App() {
     }
   }, [simMode, extraAssets, assetHistData]);
 
-  // Multi-asset mode
-  const multiAssetMode = useMemo(
-    () => EXTRA_ASSETS.some((a) => extraAssets[a].on),
-    [extraAssets],
-  );
-
   const ageYears = useMemo(() => parseAgeYears(currentAge), [currentAge]);
 
   const resolvedXMode = useMemo((): XMode => {
@@ -160,19 +148,16 @@ export default function App() {
     return xMode;
   }, [xMode, ageYears]);
 
-  // Blended capital from all active assets
   const blendedCapital = useMemo(() => {
-    if (!multiAssetMode) return parseNum(initialCapital);
     const base = parseNum(stocksVal);
     return EXTRA_ASSETS.filter((a) => extraAssets[a].on).reduce(
       (s, a) => s + parseNum(extraAssets[a].val),
       base,
     );
-  }, [multiAssetMode, initialCapital, stocksVal, extraAssets]);
+  }, [stocksVal, extraAssets]);
 
-  // Weighted blended return %
   const blendedReturnNum = useMemo(() => {
-    if (!multiAssetMode || blendedCapital <= 0) return parseNum(annualReturnPercent);
+    if (blendedCapital <= 0) return parseNum(annualReturnPercent);
     const stocksWeight = parseNum(stocksVal) / blendedCapital;
     let w = stocksWeight * parseNum(annualReturnPercent);
     for (const a of EXTRA_ASSETS) {
@@ -180,11 +165,10 @@ export default function App() {
       w += (parseNum(extraAssets[a].val) / blendedCapital) * parseNum(extraAssets[a].ret);
     }
     return w;
-  }, [multiAssetMode, blendedCapital, stocksVal, annualReturnPercent, extraAssets]);
+  }, [blendedCapital, stocksVal, annualReturnPercent, extraAssets]);
 
-  // Weighted blended std dev % (for display in MC mode)
   const blendedStdDevNum = useMemo(() => {
-    if (!multiAssetMode || blendedCapital <= 0) return parseNum(mcReturnStdDev);
+    if (blendedCapital <= 0) return parseNum(mcReturnStdDev);
     const stocksWeight = parseNum(stocksVal) / blendedCapital;
     let w = stocksWeight * parseNum(mcReturnStdDev);
     for (const a of EXTRA_ASSETS) {
@@ -192,24 +176,16 @@ export default function App() {
       w += (parseNum(extraAssets[a].val) / blendedCapital) * parseNum(extraAssets[a].sd);
     }
     return w;
-  }, [multiAssetMode, blendedCapital, stocksVal, mcReturnStdDev, extraAssets]);
+  }, [blendedCapital, stocksVal, mcReturnStdDev, extraAssets]);
 
-  // Blended monthly contribution from all active assets
   const blendedContribution = useMemo(() => {
-    if (!multiAssetMode) return parseNum(monthlyContribution);
     return EXTRA_ASSETS.filter((a) => extraAssets[a].on).reduce(
       (s, a) => s + parseNum(extraAssets[a].con),
       parseNum(stocksCon),
     );
-  }, [multiAssetMode, monthlyContribution, stocksCon, extraAssets]);
+  }, [stocksCon, extraAssets]);
 
-  const effectiveCapital = multiAssetMode ? blendedCapital : parseNum(initialCapital);
-  const effectiveReturn = multiAssetMode ? blendedReturnNum : parseNum(annualReturnPercent);
-  const effectiveContribution = multiAssetMode ? blendedContribution : parseNum(monthlyContribution);
-
-  // Asset allocations array for MC & hist modes
-  const assetAllocations = useMemo((): AssetAllocation[] | undefined => {
-    if (!multiAssetMode) return undefined;
+  const assetAllocations = useMemo((): AssetAllocation[] => {
     const allocs: AssetAllocation[] = [
       {
         assetClass: 'stocks',
@@ -228,7 +204,7 @@ export default function App() {
       });
     }
     return allocs;
-  }, [multiAssetMode, stocksVal, annualReturnPercent, mcReturnStdDev, extraAssets]);
+  }, [stocksVal, annualReturnPercent, mcReturnStdDev, extraAssets]);
 
   // Effective hist start year min (2010 when crypto active)
   const histMinYear = useMemo(
@@ -247,10 +223,8 @@ export default function App() {
   useEffect(() => {
     const qs = buildSearchParams({
       lang,
-      initialCapital,
       monthlyNeedToday,
       annualInflationPercent,
-      monthlyContribution,
       annualReturnPercent,
       horizonYears,
       currentAge,
@@ -269,10 +243,8 @@ export default function App() {
     window.history.replaceState(null, '', path);
   }, [
     lang,
-    initialCapital,
     monthlyNeedToday,
     annualInflationPercent,
-    monthlyContribution,
     annualReturnPercent,
     horizonYears,
     currentAge,
@@ -292,29 +264,25 @@ export default function App() {
     () =>
       getErrors(
         {
-          initialCapital: multiAssetMode ? String(blendedCapital) : initialCapital,
+          initialCapital: String(blendedCapital),
           monthlyNeedToday,
-          monthlyContribution: multiAssetMode ? String(blendedContribution) : monthlyContribution,
+          monthlyContribution: String(blendedContribution),
           annualInflationPercent,
-          annualReturnPercent: multiAssetMode ? String(blendedReturnNum) : annualReturnPercent,
+          annualReturnPercent: String(blendedReturnNum),
           horizonYears,
         },
         currentAge,
         lang,
         simMode === 'mc' ? { mcReturnStdDev, mcInflationStdDev } : undefined,
         simMode === 'hist',
-        multiAssetMode ? { extraAssets, stocksCon, mcMode: simMode === 'mc' } : undefined,
+        { extraAssets, stocksCon, mcMode: simMode === 'mc' },
       ),
     [
-      multiAssetMode,
       blendedCapital,
       blendedContribution,
       blendedReturnNum,
-      initialCapital,
       monthlyNeedToday,
-      monthlyContribution,
       annualInflationPercent,
-      annualReturnPercent,
       horizonYears,
       currentAge,
       lang,
@@ -328,9 +296,9 @@ export default function App() {
 
   const result = useMemo(() => {
     const baseInput = {
-      initialCapital: effectiveCapital,
+      initialCapital: blendedCapital,
       monthlyNeedToday: parseNum(monthlyNeedToday),
-      monthlyContribution: effectiveContribution,
+      monthlyContribution: blendedContribution,
       horizonYears: parseNum(horizonYears),
     };
     if (baseInput.horizonYears < 1) {
@@ -361,9 +329,7 @@ export default function App() {
       }
       const rates = histData.slice(startIdx);
 
-      if (multiAssetMode && assetAllocations) {
-        const activeExtras = EXTRA_ASSETS.filter((a) => extraAssets[a].on);
-        // Check all active asset data is loaded
+      const activeExtras = EXTRA_ASSETS.filter((a) => extraAssets[a].on);
         const allLoaded = activeExtras.every((a) => assetHistData[a] != null);
         if (!allLoaded) {
           return {
@@ -381,27 +347,23 @@ export default function App() {
           alignedRates[a as NonStocks] = assetIdx >= 0 ? data.slice(assetIdx) : data;
         }
         return { ...simulateHistorical(baseInput, rates, assetAllocations, alignedRates), invalid: false };
-      }
-
-      return { ...simulateHistorical(baseInput, rates), invalid: false };
     }
     const input = {
       ...baseInput,
       annualInflationPercent: parseNum(annualInflationPercent),
-      annualReturnPercent: effectiveReturn,
+      annualReturnPercent: blendedReturnNum,
     };
     return { ...simulate(input), truncated: false, invalid: false };
   }, [
     simMode,
     histData,
     histStartYear,
-    effectiveCapital,
-    effectiveReturn,
-    effectiveContribution,
+    blendedCapital,
+    blendedReturnNum,
+    blendedContribution,
     monthlyNeedToday,
     annualInflationPercent,
     horizonYears,
-    multiAssetMode,
     assetAllocations,
     assetHistData,
     extraAssets,
@@ -412,13 +374,13 @@ export default function App() {
     if (!mcEnabled || result.invalid) return null;
     if (errors.mcReturnStdDev || errors.mcInflationStdDev) return null;
     return {
-      initialCapital: effectiveCapital,
+      initialCapital: blendedCapital,
       monthlyNeedToday: parseNum(monthlyNeedToday),
       annualInflationPercent: parseNum(annualInflationPercent),
-      monthlyContribution: effectiveContribution,
-      annualReturnPercent: effectiveReturn,
+      monthlyContribution: blendedContribution,
+      annualReturnPercent: blendedReturnNum,
       horizonYears: parseNum(horizonYears),
-      returnStdDevPercent: multiAssetMode ? blendedStdDevNum : parseNum(mcReturnStdDev),
+      returnStdDevPercent: blendedStdDevNum,
       inflationStdDevPercent: parseNum(mcInflationStdDev),
       runCount: parseNum(mcRunCount),
       assetAllocations,
@@ -428,17 +390,15 @@ export default function App() {
     result.invalid,
     errors.mcReturnStdDev,
     errors.mcInflationStdDev,
-    effectiveCapital,
-    effectiveReturn,
-    effectiveContribution,
+    blendedCapital,
+    blendedReturnNum,
+    blendedContribution,
+    blendedStdDevNum,
     monthlyNeedToday,
     annualInflationPercent,
     horizonYears,
-    mcReturnStdDev,
     mcInflationStdDev,
     mcRunCount,
-    multiAssetMode,
-    blendedStdDevNum,
     assetAllocations,
   ]);
 
@@ -527,13 +487,6 @@ export default function App() {
   }
 
   function handleToggleAsset(asset: ExtraAsset, on: boolean) {
-    if (on) {
-      const anyOtherOn = EXTRA_ASSETS.filter((a) => a !== asset).some((a) => extraAssets[a].on);
-      if (!anyOtherOn) {
-        setStocksVal(initialCapital);
-        setStocksCon(monthlyContribution);
-      }
-    }
     setCryptoClampNotice(false);
     updateExtraAsset(asset, 'on', on);
   }
@@ -576,12 +529,8 @@ export default function App() {
       <InputForm
         lang={lang}
         errors={errors}
-        initialCapital={initialCapital}
-        setInitialCapital={setInitialCapital}
         monthlyNeedToday={monthlyNeedToday}
         setMonthlyNeedToday={setMonthlyNeedToday}
-        monthlyContribution={monthlyContribution}
-        setMonthlyContribution={setMonthlyContribution}
         annualInflationPercent={annualInflationPercent}
         setAnnualInflationPercent={setAnnualInflationPercent}
         annualReturnPercent={annualReturnPercent}
@@ -605,7 +554,6 @@ export default function App() {
         setMcInflationStdDev={setMcInflationStdDev}
         mcStatus={mcStatus}
         onRerunMC={handleRerunMC}
-        multiAssetMode={multiAssetMode}
         blendedCapital={blendedCapital}
         blendedContribution={blendedContribution}
         blendedReturnNum={blendedReturnNum}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,6 +71,7 @@ export default function App() {
   );
 
   // Asset allocation state
+  const [stocksOn, setStocksOn] = useState(() => urlInit.stocksOn !== false);
   const [extraAssets, setExtraAssets] = useState<Record<ExtraAsset, ExtraAssetState>>(
     () => urlInit.extraAssets ?? { ...EXTRA_ASSET_DEFAULTS },
   );
@@ -149,51 +150,57 @@ export default function App() {
   }, [xMode, ageYears]);
 
   const blendedCapital = useMemo(() => {
-    const base = parseNum(stocksVal);
+    const base = stocksOn ? parseNum(stocksVal) : 0;
     return EXTRA_ASSETS.filter((a) => extraAssets[a].on).reduce(
       (s, a) => s + parseNum(extraAssets[a].val),
       base,
     );
-  }, [stocksVal, extraAssets]);
+  }, [stocksOn, stocksVal, extraAssets]);
 
   const blendedReturnNum = useMemo(() => {
     if (blendedCapital <= 0) return parseNum(annualReturnPercent);
-    const stocksWeight = parseNum(stocksVal) / blendedCapital;
-    let w = stocksWeight * parseNum(annualReturnPercent);
+    let w = 0;
+    if (stocksOn) {
+      w += (parseNum(stocksVal) / blendedCapital) * parseNum(annualReturnPercent);
+    }
     for (const a of EXTRA_ASSETS) {
       if (!extraAssets[a].on) continue;
       w += (parseNum(extraAssets[a].val) / blendedCapital) * parseNum(extraAssets[a].ret);
     }
     return w;
-  }, [blendedCapital, stocksVal, annualReturnPercent, extraAssets]);
+  }, [blendedCapital, stocksOn, stocksVal, annualReturnPercent, extraAssets]);
 
   const blendedStdDevNum = useMemo(() => {
     if (blendedCapital <= 0) return parseNum(mcReturnStdDev);
-    const stocksWeight = parseNum(stocksVal) / blendedCapital;
-    let w = stocksWeight * parseNum(mcReturnStdDev);
+    let w = 0;
+    if (stocksOn) {
+      w += (parseNum(stocksVal) / blendedCapital) * parseNum(mcReturnStdDev);
+    }
     for (const a of EXTRA_ASSETS) {
       if (!extraAssets[a].on) continue;
       w += (parseNum(extraAssets[a].val) / blendedCapital) * parseNum(extraAssets[a].sd);
     }
     return w;
-  }, [blendedCapital, stocksVal, mcReturnStdDev, extraAssets]);
+  }, [blendedCapital, stocksOn, stocksVal, mcReturnStdDev, extraAssets]);
 
   const blendedContribution = useMemo(() => {
+    const base = stocksOn ? parseNum(stocksCon) : 0;
     return EXTRA_ASSETS.filter((a) => extraAssets[a].on).reduce(
       (s, a) => s + parseNum(extraAssets[a].con),
-      parseNum(stocksCon),
+      base,
     );
-  }, [stocksCon, extraAssets]);
+  }, [stocksOn, stocksCon, extraAssets]);
 
   const assetAllocations = useMemo((): AssetAllocation[] => {
-    const allocs: AssetAllocation[] = [
-      {
+    const allocs: AssetAllocation[] = [];
+    if (stocksOn) {
+      allocs.push({
         assetClass: 'stocks',
         value: parseNum(stocksVal),
         annualReturnPercent: parseNum(annualReturnPercent),
         returnStdDevPercent: parseNum(mcReturnStdDev),
-      },
-    ];
+      });
+    }
     for (const a of EXTRA_ASSETS) {
       if (!extraAssets[a].on) continue;
       allocs.push({
@@ -204,7 +211,7 @@ export default function App() {
       });
     }
     return allocs;
-  }, [stocksVal, annualReturnPercent, mcReturnStdDev, extraAssets]);
+  }, [stocksOn, stocksVal, annualReturnPercent, mcReturnStdDev, extraAssets]);
 
   // Effective hist start year min (2010 when crypto active)
   const histMinYear = useMemo(
@@ -234,6 +241,7 @@ export default function App() {
       mcReturnStdDev,
       mcInflationStdDev,
       histStartYear,
+      stocksOn,
       stocksVal,
       stocksCon,
       extraAssets,
@@ -254,6 +262,7 @@ export default function App() {
     mcReturnStdDev,
     mcInflationStdDev,
     histStartYear,
+    stocksOn,
     stocksVal,
     stocksCon,
     extraAssets,
@@ -486,7 +495,19 @@ export default function App() {
     }));
   }
 
+  function handleToggleStocks(on: boolean) {
+    if (!on) {
+      const anyExtraOn = EXTRA_ASSETS.some((a) => extraAssets[a].on);
+      if (!anyExtraOn) return; // can't turn off last active asset
+    }
+    setStocksOn(on);
+  }
+
   function handleToggleAsset(asset: ExtraAsset, on: boolean) {
+    if (!on) {
+      const otherExtrasOn = EXTRA_ASSETS.filter((a) => a !== asset).some((a) => extraAssets[a].on);
+      if (!stocksOn && !otherExtrasOn) return; // can't turn off last active asset
+    }
     setCryptoClampNotice(false);
     updateExtraAsset(asset, 'on', on);
   }
@@ -559,12 +580,14 @@ export default function App() {
         blendedReturnNum={blendedReturnNum}
         blendedStdDevNum={blendedStdDevNum}
         extraAssets={extraAssets}
+        stocksOn={stocksOn}
         stocksVal={stocksVal}
         setStocksVal={setStocksVal}
         stocksCon={stocksCon}
         setStocksCon={setStocksCon}
         allocOrder={allocOrder}
         setAllocOrder={setAllocOrder}
+        onToggleStocks={handleToggleStocks}
         onToggleAsset={handleToggleAsset}
         onUpdateAsset={updateExtraAsset}
         cryptoClampNotice={cryptoClampNotice}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,6 +83,9 @@ export default function App() {
   const [stocksVal, setStocksVal] = useState<string>(
     () => urlInit.stocksVal ?? String(DEFAULTS.initialCapital),
   );
+  const [stocksCon, setStocksCon] = useState<string>(
+    () => urlInit.stocksCon ?? String(DEFAULTS.monthlyContribution),
+  );
   const [allocOrder, setAllocOrder] = useState<string[]>(
     () => urlInit.allocOrder ?? [...DEFAULT_ALLOC_ORDER],
   );
@@ -191,8 +194,18 @@ export default function App() {
     return w;
   }, [multiAssetMode, blendedCapital, stocksVal, mcReturnStdDev, extraAssets]);
 
+  // Blended monthly contribution from all active assets
+  const blendedContribution = useMemo(() => {
+    if (!multiAssetMode) return parseNum(monthlyContribution);
+    return EXTRA_ASSETS.filter((a) => extraAssets[a].on).reduce(
+      (s, a) => s + parseNum(extraAssets[a].con),
+      parseNum(stocksCon),
+    );
+  }, [multiAssetMode, monthlyContribution, stocksCon, extraAssets]);
+
   const effectiveCapital = multiAssetMode ? blendedCapital : parseNum(initialCapital);
   const effectiveReturn = multiAssetMode ? blendedReturnNum : parseNum(annualReturnPercent);
+  const effectiveContribution = multiAssetMode ? blendedContribution : parseNum(monthlyContribution);
 
   // Asset allocations array for MC & hist modes
   const assetAllocations = useMemo((): AssetAllocation[] | undefined => {
@@ -248,6 +261,7 @@ export default function App() {
       mcInflationStdDev,
       histStartYear,
       stocksVal,
+      stocksCon,
       extraAssets,
       allocOrder,
     });
@@ -269,6 +283,7 @@ export default function App() {
     mcInflationStdDev,
     histStartYear,
     stocksVal,
+    stocksCon,
     extraAssets,
     allocOrder,
   ]);
@@ -279,7 +294,7 @@ export default function App() {
         {
           initialCapital: multiAssetMode ? String(blendedCapital) : initialCapital,
           monthlyNeedToday,
-          monthlyContribution,
+          monthlyContribution: multiAssetMode ? String(blendedContribution) : monthlyContribution,
           annualInflationPercent,
           annualReturnPercent: multiAssetMode ? String(blendedReturnNum) : annualReturnPercent,
           horizonYears,
@@ -288,11 +303,12 @@ export default function App() {
         lang,
         simMode === 'mc' ? { mcReturnStdDev, mcInflationStdDev } : undefined,
         simMode === 'hist',
-        multiAssetMode ? { extraAssets, mcMode: simMode === 'mc' } : undefined,
+        multiAssetMode ? { extraAssets, stocksCon, mcMode: simMode === 'mc' } : undefined,
       ),
     [
       multiAssetMode,
       blendedCapital,
+      blendedContribution,
       blendedReturnNum,
       initialCapital,
       monthlyNeedToday,
@@ -306,6 +322,7 @@ export default function App() {
       mcReturnStdDev,
       mcInflationStdDev,
       extraAssets,
+      stocksCon,
     ],
   );
 
@@ -313,7 +330,7 @@ export default function App() {
     const baseInput = {
       initialCapital: effectiveCapital,
       monthlyNeedToday: parseNum(monthlyNeedToday),
-      monthlyContribution: parseNum(monthlyContribution),
+      monthlyContribution: effectiveContribution,
       horizonYears: parseNum(horizonYears),
     };
     if (baseInput.horizonYears < 1) {
@@ -380,9 +397,9 @@ export default function App() {
     histStartYear,
     effectiveCapital,
     effectiveReturn,
+    effectiveContribution,
     monthlyNeedToday,
     annualInflationPercent,
-    monthlyContribution,
     horizonYears,
     multiAssetMode,
     assetAllocations,
@@ -398,7 +415,7 @@ export default function App() {
       initialCapital: effectiveCapital,
       monthlyNeedToday: parseNum(monthlyNeedToday),
       annualInflationPercent: parseNum(annualInflationPercent),
-      monthlyContribution: parseNum(monthlyContribution),
+      monthlyContribution: effectiveContribution,
       annualReturnPercent: effectiveReturn,
       horizonYears: parseNum(horizonYears),
       returnStdDevPercent: multiAssetMode ? blendedStdDevNum : parseNum(mcReturnStdDev),
@@ -413,9 +430,9 @@ export default function App() {
     errors.mcInflationStdDev,
     effectiveCapital,
     effectiveReturn,
+    effectiveContribution,
     monthlyNeedToday,
     annualInflationPercent,
-    monthlyContribution,
     horizonYears,
     mcReturnStdDev,
     mcInflationStdDev,
@@ -514,6 +531,7 @@ export default function App() {
       const anyOtherOn = EXTRA_ASSETS.filter((a) => a !== asset).some((a) => extraAssets[a].on);
       if (!anyOtherOn) {
         setStocksVal(initialCapital);
+        setStocksCon(monthlyContribution);
       }
     }
     setCryptoClampNotice(false);
@@ -589,11 +607,14 @@ export default function App() {
         onRerunMC={handleRerunMC}
         multiAssetMode={multiAssetMode}
         blendedCapital={blendedCapital}
+        blendedContribution={blendedContribution}
         blendedReturnNum={blendedReturnNum}
         blendedStdDevNum={blendedStdDevNum}
         extraAssets={extraAssets}
         stocksVal={stocksVal}
         setStocksVal={setStocksVal}
+        stocksCon={stocksCon}
+        setStocksCon={setStocksCon}
         allocOrder={allocOrder}
         setAllocOrder={setAllocOrder}
         onToggleAsset={handleToggleAsset}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,22 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { tr, type Lang } from './i18n';
-import { simulate, simulateHistorical, type MCResult, type MonteCarloInput } from './model/simulate';
-import { DEFAULTS, MC_DEFAULTS, HIST_DEFAULT_START_YEAR, type XMode, type SimMode } from './constants';
+import { simulate, simulateHistorical, type MCResult, type MonteCarloInput, type AssetAllocation } from './model/simulate';
+import {
+  DEFAULTS,
+  MC_DEFAULTS,
+  HIST_DEFAULT_START_YEAR,
+  HIST_CRYPTO_FIRST_YEAR,
+  type XMode,
+  type SimMode,
+  EXTRA_ASSETS,
+  type ExtraAsset,
+  type ExtraAssetState,
+  EXTRA_ASSET_DEFAULTS,
+  DEFAULT_ALLOC_ORDER,
+} from './constants';
 import { parseNum, parseAgeYears, getErrors } from './lib';
 import { readUrlState, buildSearchParams } from './url';
-import { fetchHistoricalRates, type HistoricalRate } from './data/historical';
+import { fetchHistoricalRates, fetchAssetHistoricalRates, type HistoricalRate, type AssetHistoricalRate } from './data/historical';
 import { InputForm } from './components/InputForm';
 import { OutcomePanel } from './components/OutcomePanel';
 import { SimulationChart } from './components/SimulationChart';
@@ -64,6 +76,18 @@ export default function App() {
     () => urlInit.mcInflationStdDev ?? MC_DEFAULTS.mcInflationStdDev,
   );
 
+  // Asset allocation state
+  const [extraAssets, setExtraAssets] = useState<Record<ExtraAsset, ExtraAssetState>>(
+    () => urlInit.extraAssets ?? { ...EXTRA_ASSET_DEFAULTS },
+  );
+  const [stocksVal, setStocksVal] = useState<string>(
+    () => urlInit.stocksVal ?? String(DEFAULTS.initialCapital),
+  );
+  const [allocOrder, setAllocOrder] = useState<string[]>(
+    () => urlInit.allocOrder ?? [...DEFAULT_ALLOC_ORDER],
+  );
+  const [cryptoClampNotice, setCryptoClampNotice] = useState(false);
+
   const mcEnabled = simMode === 'mc';
 
   // Monte Carlo result state
@@ -73,6 +97,7 @@ export default function App() {
   // Historical data state
   const [histData, setHistData] = useState<HistoricalRate[] | null>(null);
   const [histDataError, setHistDataError] = useState<string | null>(null);
+  const [assetHistData, setAssetHistData] = useState<Partial<Record<ExtraAsset, AssetHistoricalRate[]>>>({});
 
   // Worker management
   const workerRef = useRef<Worker | null>(null);
@@ -107,12 +132,104 @@ export default function App() {
       .catch((e: unknown) => setHistDataError(String(e)));
   }, []);
 
+  // Fetch per-asset historical data when needed in hist mode
+  useEffect(() => {
+    if (simMode !== 'hist') return;
+    for (const asset of EXTRA_ASSETS) {
+      if (!extraAssets[asset].on) continue;
+      if (assetHistData[asset]) continue;
+      fetchAssetHistoricalRates(asset).then((data) => {
+        setAssetHistData((prev) => ({ ...prev, [asset]: data }));
+      }).catch(console.error);
+    }
+  }, [simMode, extraAssets, assetHistData]);
+
+  // Multi-asset mode
+  const multiAssetMode = useMemo(
+    () => EXTRA_ASSETS.some((a) => extraAssets[a].on),
+    [extraAssets],
+  );
+
   const ageYears = useMemo(() => parseAgeYears(currentAge), [currentAge]);
 
   const resolvedXMode = useMemo((): XMode => {
     if (xMode === 'age') return ageYears !== null ? 'age' : 'rel';
     return xMode;
   }, [xMode, ageYears]);
+
+  // Blended capital from all active assets
+  const blendedCapital = useMemo(() => {
+    if (!multiAssetMode) return parseNum(initialCapital);
+    const base = parseNum(stocksVal);
+    return EXTRA_ASSETS.filter((a) => extraAssets[a].on).reduce(
+      (s, a) => s + parseNum(extraAssets[a].val),
+      base,
+    );
+  }, [multiAssetMode, initialCapital, stocksVal, extraAssets]);
+
+  // Weighted blended return %
+  const blendedReturnNum = useMemo(() => {
+    if (!multiAssetMode || blendedCapital <= 0) return parseNum(annualReturnPercent);
+    const stocksWeight = parseNum(stocksVal) / blendedCapital;
+    let w = stocksWeight * parseNum(annualReturnPercent);
+    for (const a of EXTRA_ASSETS) {
+      if (!extraAssets[a].on) continue;
+      w += (parseNum(extraAssets[a].val) / blendedCapital) * parseNum(extraAssets[a].ret);
+    }
+    return w;
+  }, [multiAssetMode, blendedCapital, stocksVal, annualReturnPercent, extraAssets]);
+
+  // Weighted blended std dev % (for display in MC mode)
+  const blendedStdDevNum = useMemo(() => {
+    if (!multiAssetMode || blendedCapital <= 0) return parseNum(mcReturnStdDev);
+    const stocksWeight = parseNum(stocksVal) / blendedCapital;
+    let w = stocksWeight * parseNum(mcReturnStdDev);
+    for (const a of EXTRA_ASSETS) {
+      if (!extraAssets[a].on) continue;
+      w += (parseNum(extraAssets[a].val) / blendedCapital) * parseNum(extraAssets[a].sd);
+    }
+    return w;
+  }, [multiAssetMode, blendedCapital, stocksVal, mcReturnStdDev, extraAssets]);
+
+  const effectiveCapital = multiAssetMode ? blendedCapital : parseNum(initialCapital);
+  const effectiveReturn = multiAssetMode ? blendedReturnNum : parseNum(annualReturnPercent);
+
+  // Asset allocations array for MC & hist modes
+  const assetAllocations = useMemo((): AssetAllocation[] | undefined => {
+    if (!multiAssetMode) return undefined;
+    const allocs: AssetAllocation[] = [
+      {
+        assetClass: 'stocks',
+        value: parseNum(stocksVal),
+        annualReturnPercent: parseNum(annualReturnPercent),
+        returnStdDevPercent: parseNum(mcReturnStdDev),
+      },
+    ];
+    for (const a of EXTRA_ASSETS) {
+      if (!extraAssets[a].on) continue;
+      allocs.push({
+        assetClass: a,
+        value: parseNum(extraAssets[a].val),
+        annualReturnPercent: parseNum(extraAssets[a].ret),
+        returnStdDevPercent: parseNum(extraAssets[a].sd),
+      });
+    }
+    return allocs;
+  }, [multiAssetMode, stocksVal, annualReturnPercent, mcReturnStdDev, extraAssets]);
+
+  // Effective hist start year min (2010 when crypto active)
+  const histMinYear = useMemo(
+    () => (extraAssets.crypto.on ? HIST_CRYPTO_FIRST_YEAR : 1970),
+    [extraAssets.crypto.on],
+  );
+
+  // Clamp histStartYear when crypto is toggled on
+  useEffect(() => {
+    if (extraAssets.crypto.on && histStartYear < HIST_CRYPTO_FIRST_YEAR) {
+      setHistStartYear(HIST_CRYPTO_FIRST_YEAR);
+      setCryptoClampNotice(true);
+    }
+  }, [extraAssets.crypto.on, histStartYear]);
 
   useEffect(() => {
     const qs = buildSearchParams({
@@ -130,6 +247,9 @@ export default function App() {
       mcReturnStdDev,
       mcInflationStdDev,
       histStartYear,
+      stocksVal,
+      extraAssets,
+      allocOrder,
     });
     const path = `${window.location.pathname}?${qs}`;
     window.history.replaceState(null, '', path);
@@ -148,25 +268,32 @@ export default function App() {
     mcReturnStdDev,
     mcInflationStdDev,
     histStartYear,
+    stocksVal,
+    extraAssets,
+    allocOrder,
   ]);
 
   const errors = useMemo(
     () =>
       getErrors(
         {
-          initialCapital,
+          initialCapital: multiAssetMode ? String(blendedCapital) : initialCapital,
           monthlyNeedToday,
           monthlyContribution,
           annualInflationPercent,
-          annualReturnPercent,
+          annualReturnPercent: multiAssetMode ? String(blendedReturnNum) : annualReturnPercent,
           horizonYears,
         },
         currentAge,
         lang,
         simMode === 'mc' ? { mcReturnStdDev, mcInflationStdDev } : undefined,
         simMode === 'hist',
+        multiAssetMode ? { extraAssets, mcMode: simMode === 'mc' } : undefined,
       ),
     [
+      multiAssetMode,
+      blendedCapital,
+      blendedReturnNum,
       initialCapital,
       monthlyNeedToday,
       monthlyContribution,
@@ -178,12 +305,13 @@ export default function App() {
       simMode,
       mcReturnStdDev,
       mcInflationStdDev,
+      extraAssets,
     ],
   );
 
   const result = useMemo(() => {
     const baseInput = {
-      initialCapital: parseNum(initialCapital),
+      initialCapital: effectiveCapital,
       monthlyNeedToday: parseNum(monthlyNeedToday),
       monthlyContribution: parseNum(monthlyContribution),
       horizonYears: parseNum(horizonYears),
@@ -215,24 +343,51 @@ export default function App() {
         };
       }
       const rates = histData.slice(startIdx);
+
+      if (multiAssetMode && assetAllocations) {
+        const activeExtras = EXTRA_ASSETS.filter((a) => extraAssets[a].on);
+        // Check all active asset data is loaded
+        const allLoaded = activeExtras.every((a) => assetHistData[a] != null);
+        if (!allLoaded) {
+          return {
+            series: [] as { year: number; capital: number; annualExpenses: number; passiveReturn: number }[],
+            crossoverYear: null as number | null,
+            truncated: false,
+            invalid: true,
+          };
+        }
+        type NonStocks = Exclude<import('./data/historical').AssetClass, 'stocks'>;
+        const alignedRates: Partial<Record<NonStocks, { returnPct: number }[]>> = {};
+        for (const a of activeExtras) {
+          const data = assetHistData[a]!;
+          const assetIdx = data.findIndex((d) => d.year === histStartYear);
+          alignedRates[a as NonStocks] = assetIdx >= 0 ? data.slice(assetIdx) : data;
+        }
+        return { ...simulateHistorical(baseInput, rates, assetAllocations, alignedRates), invalid: false };
+      }
+
       return { ...simulateHistorical(baseInput, rates), invalid: false };
     }
     const input = {
       ...baseInput,
       annualInflationPercent: parseNum(annualInflationPercent),
-      annualReturnPercent: parseNum(annualReturnPercent),
+      annualReturnPercent: effectiveReturn,
     };
     return { ...simulate(input), truncated: false, invalid: false };
   }, [
     simMode,
     histData,
     histStartYear,
-    initialCapital,
+    effectiveCapital,
+    effectiveReturn,
     monthlyNeedToday,
     annualInflationPercent,
     monthlyContribution,
-    annualReturnPercent,
     horizonYears,
+    multiAssetMode,
+    assetAllocations,
+    assetHistData,
+    extraAssets,
   ]);
 
   // Compute MC input params (null when MC cannot run)
@@ -240,30 +395,34 @@ export default function App() {
     if (!mcEnabled || result.invalid) return null;
     if (errors.mcReturnStdDev || errors.mcInflationStdDev) return null;
     return {
-      initialCapital: parseNum(initialCapital),
+      initialCapital: effectiveCapital,
       monthlyNeedToday: parseNum(monthlyNeedToday),
       annualInflationPercent: parseNum(annualInflationPercent),
       monthlyContribution: parseNum(monthlyContribution),
-      annualReturnPercent: parseNum(annualReturnPercent),
+      annualReturnPercent: effectiveReturn,
       horizonYears: parseNum(horizonYears),
-      returnStdDevPercent: parseNum(mcReturnStdDev),
+      returnStdDevPercent: multiAssetMode ? blendedStdDevNum : parseNum(mcReturnStdDev),
       inflationStdDevPercent: parseNum(mcInflationStdDev),
       runCount: parseNum(mcRunCount),
+      assetAllocations,
     };
   }, [
     mcEnabled,
     result.invalid,
     errors.mcReturnStdDev,
     errors.mcInflationStdDev,
-    initialCapital,
+    effectiveCapital,
+    effectiveReturn,
     monthlyNeedToday,
     annualInflationPercent,
     monthlyContribution,
-    annualReturnPercent,
     horizonYears,
     mcReturnStdDev,
     mcInflationStdDev,
     mcRunCount,
+    multiAssetMode,
+    blendedStdDevNum,
+    assetAllocations,
   ]);
 
   // Launch a worker run; terminates any in-progress run first
@@ -343,6 +502,24 @@ export default function App() {
     return histStartYear + result.series[result.series.length - 1].year;
   }, [simMode, histStartYear, result.series]);
 
+  function updateExtraAsset(asset: ExtraAsset, field: keyof ExtraAssetState, value: string | boolean) {
+    setExtraAssets((prev) => ({
+      ...prev,
+      [asset]: { ...prev[asset], [field]: value },
+    }));
+  }
+
+  function handleToggleAsset(asset: ExtraAsset, on: boolean) {
+    if (on) {
+      const anyOtherOn = EXTRA_ASSETS.filter((a) => a !== asset).some((a) => extraAssets[a].on);
+      if (!anyOtherOn) {
+        setStocksVal(initialCapital);
+      }
+    }
+    setCryptoClampNotice(false);
+    updateExtraAsset(asset, 'on', on);
+  }
+
   return (
     <div className='app'>
       <header className='header'>
@@ -399,6 +576,7 @@ export default function App() {
         setSimMode={setSimMode}
         histStartYear={histStartYear}
         setHistStartYear={setHistStartYear}
+        histMinYear={histMinYear}
         histData={histData}
         histDataError={histDataError}
         mcRunCount={mcRunCount}
@@ -409,6 +587,19 @@ export default function App() {
         setMcInflationStdDev={setMcInflationStdDev}
         mcStatus={mcStatus}
         onRerunMC={handleRerunMC}
+        multiAssetMode={multiAssetMode}
+        blendedCapital={blendedCapital}
+        blendedReturnNum={blendedReturnNum}
+        blendedStdDevNum={blendedStdDevNum}
+        extraAssets={extraAssets}
+        stocksVal={stocksVal}
+        setStocksVal={setStocksVal}
+        allocOrder={allocOrder}
+        setAllocOrder={setAllocOrder}
+        onToggleAsset={handleToggleAsset}
+        onUpdateAsset={updateExtraAsset}
+        cryptoClampNotice={cryptoClampNotice}
+        onDismissCryptoClamp={() => setCryptoClampNotice(false)}
       />
 
       <OutcomePanel

--- a/src/components/InputForm.tsx
+++ b/src/components/InputForm.tsx
@@ -68,11 +68,14 @@ interface InputFormProps {
   // multi-asset
   multiAssetMode: boolean;
   blendedCapital: number;
+  blendedContribution: number;
   blendedReturnNum: number;
   blendedStdDevNum: number;
   extraAssets: Record<ExtraAsset, ExtraAssetState>;
   stocksVal: string;
   setStocksVal: (v: string) => void;
+  stocksCon: string;
+  setStocksCon: (v: string) => void;
   allocOrder: string[];
   setAllocOrder: (v: string[]) => void;
   onToggleAsset: (asset: ExtraAsset, on: boolean) => void;
@@ -255,11 +258,14 @@ export function InputForm({
   onRerunMC,
   multiAssetMode,
   blendedCapital,
+  blendedContribution,
   blendedReturnNum,
   blendedStdDevNum,
   extraAssets,
   stocksVal,
   setStocksVal,
+  stocksCon,
+  setStocksCon,
   allocOrder,
   setAllocOrder,
   onToggleAsset,
@@ -280,10 +286,23 @@ export function InputForm({
     ? parseNum(stocksVal) + EXTRA_ASSETS.filter((a) => extraAssets[a].on).reduce((s, a) => s + parseNum(extraAssets[a].val), 0)
     : 0;
 
+  const totalAllocCon = multiAssetMode
+    ? parseNum(stocksCon) + EXTRA_ASSETS.filter((a) => extraAssets[a].on).reduce((s, a) => s + parseNum(extraAssets[a].con), 0)
+    : 0;
+
   const barSegments: BarSegment[] = multiAssetMode && activeAssetKeys.length >= 2
     ? activeAssetKeys.map((k) => {
         const val = k === 'stocks' ? parseNum(stocksVal) : parseNum(extraAssets[k as ExtraAsset].val);
         const pct = totalAllocVal > 0 ? (val / totalAllocVal) * 100 : 0;
+        const labelKey = k === 'stocks' ? 'form.assetAllocation.stocksLabel' : ASSET_LABEL_KEYS[k as ExtraAsset];
+        return { key: k, label: tr(lang, labelKey), color: ASSET_COLORS[k as import('../data/historical').AssetClass], value: val, pct };
+      })
+    : [];
+
+  const conBarSegments: BarSegment[] = multiAssetMode && activeAssetKeys.length >= 2 && totalAllocCon > 0
+    ? activeAssetKeys.map((k) => {
+        const val = k === 'stocks' ? parseNum(stocksCon) : parseNum(extraAssets[k as ExtraAsset].con);
+        const pct = totalAllocCon > 0 ? (val / totalAllocCon) * 100 : 0;
         const labelKey = k === 'stocks' ? 'form.assetAllocation.stocksLabel' : ASSET_LABEL_KEYS[k as ExtraAsset];
         return { key: k, label: tr(lang, labelKey), color: ASSET_COLORS[k as import('../data/historical').AssetClass], value: val, pct };
       })
@@ -326,6 +345,29 @@ export function InputForm({
     const next = [...allocOrder];
     [next[idx], next[idx + 1]] = [next[idx + 1], next[idx]];
     setAllocOrder(next);
+  }
+
+  function handleConDragRebalance(leftKey: string, rightKey: string, deltaValue: number) {
+    const MIN = 0;
+    if (leftKey === 'stocks') {
+      const newLeft = Math.max(MIN, parseNum(stocksCon) + deltaValue);
+      const newRight = Math.max(MIN, parseNum(rightKey === 'stocks' ? stocksCon : extraAssets[rightKey as ExtraAsset].con) - deltaValue);
+      setStocksCon(String(Math.round(newLeft)));
+      if (rightKey !== 'stocks') onUpdateAsset(rightKey as ExtraAsset, 'con', String(Math.round(newRight)));
+    } else if (rightKey === 'stocks') {
+      const leftAsset = leftKey as ExtraAsset;
+      const newLeft = Math.max(MIN, parseNum(extraAssets[leftAsset].con) + deltaValue);
+      const newRight = Math.max(MIN, parseNum(stocksCon) - deltaValue);
+      onUpdateAsset(leftAsset, 'con', String(Math.round(newLeft)));
+      setStocksCon(String(Math.round(newRight)));
+    } else {
+      const leftAsset = leftKey as ExtraAsset;
+      const rightAsset = rightKey as ExtraAsset;
+      const newLeft = Math.max(MIN, parseNum(extraAssets[leftAsset].con) + deltaValue);
+      const newRight = Math.max(MIN, parseNum(extraAssets[rightAsset].con) - deltaValue);
+      onUpdateAsset(leftAsset, 'con', String(Math.round(newLeft)));
+      onUpdateAsset(rightAsset, 'con', String(Math.round(newRight)));
+    }
   }
 
   return (
@@ -381,7 +423,7 @@ export function InputForm({
           </div>
         </div>
 
-        <div className='field'>
+        <div className={`field${multiAssetMode ? ' field--readonly' : ''}`}>
           <label className='field-label' htmlFor='monthlyContribution'>
             <span className='field-label-head'>
               <span className='field-label-text'>{tr(lang, 'form.monthlyContribution.label')}</span>
@@ -393,19 +435,22 @@ export function InputForm({
               id='monthlyContribution'
               type='text'
               inputMode='decimal'
-              value={monthlyContribution}
-              onChange={(e) => setMonthlyContribution(e.target.value)}
-              className={errors.monthlyContribution ? 'input-error' : ''}
+              value={multiAssetMode ? String(Math.round(blendedContribution)) : monthlyContribution}
+              onChange={(e) => !multiAssetMode && setMonthlyContribution(e.target.value)}
+              readOnly={multiAssetMode}
+              className={!multiAssetMode && errors.monthlyContribution ? 'input-error' : ''}
             />
-            <input
-              type='range'
-              min={SLIDERS.monthlyContribution.min}
-              max={SLIDERS.monthlyContribution.max}
-              step={SLIDERS.monthlyContribution.step}
-              value={sliderVal(monthlyContribution, SLIDERS.monthlyContribution)}
-              onChange={(e) => setMonthlyContribution(e.target.value)}
-            />
-            {errors.monthlyContribution && <span className='field-error'>{errors.monthlyContribution}</span>}
+            {!multiAssetMode && (
+              <input
+                type='range'
+                min={SLIDERS.monthlyContribution.min}
+                max={SLIDERS.monthlyContribution.max}
+                step={SLIDERS.monthlyContribution.step}
+                value={sliderVal(monthlyContribution, SLIDERS.monthlyContribution)}
+                onChange={(e) => setMonthlyContribution(e.target.value)}
+              />
+            )}
+            {!multiAssetMode && errors.monthlyContribution && <span className='field-error'>{errors.monthlyContribution}</span>}
           </div>
         </div>
 
@@ -568,6 +613,25 @@ export function InputForm({
                   />
                 </div>
                 <div className='alloc-field'>
+                  <label className='alloc-field-label'>{tr(lang, 'form.assetAllocation.contributionLabel')}</label>
+                  <input
+                    type='text'
+                    inputMode='decimal'
+                    value={stocksCon}
+                    onChange={(e) => setStocksCon(e.target.value)}
+                    className={errors.stocks_con ? 'input-error' : ''}
+                  />
+                  <input
+                    type='range'
+                    min={0}
+                    max={ASSET_VAL_SLIDER.max / 10}
+                    step={50}
+                    value={clamp(parseNum(stocksCon), 0, ASSET_VAL_SLIDER.max / 10)}
+                    onChange={(e) => setStocksCon(e.target.value)}
+                  />
+                  {errors.stocks_con && <span className='field-error'>{errors.stocks_con}</span>}
+                </div>
+                <div className='alloc-field'>
                   <label className='alloc-field-label'>{tr(lang, 'form.assetAllocation.returnLabel')}</label>
                   <input
                     type='text'
@@ -615,6 +679,7 @@ export function InputForm({
             const a = extraAssets[asset];
             const label = tr(lang, ASSET_LABEL_KEYS[asset]);
             const valErr = errors[`${asset}_val` as keyof AllErrors];
+            const conErr = errors[`${asset}_con` as keyof AllErrors];
             const retErr = errors[`${asset}_ret` as keyof AllErrors];
             const sdErr = errors[`${asset}_sd` as keyof AllErrors];
             return (
@@ -656,6 +721,26 @@ export function InputForm({
                         onChange={(e) => onUpdateAsset(asset, 'val', e.target.value)}
                       />
                       {valErr && <span className='field-error'>{valErr}</span>}
+                    </div>
+
+                    <div className='alloc-field'>
+                      <label className='alloc-field-label'>{tr(lang, 'form.assetAllocation.contributionLabel')}</label>
+                      <input
+                        type='text'
+                        inputMode='decimal'
+                        value={a.con}
+                        onChange={(e) => onUpdateAsset(asset, 'con', e.target.value)}
+                        className={conErr ? 'input-error' : ''}
+                      />
+                      <input
+                        type='range'
+                        min={0}
+                        max={ASSET_VAL_SLIDER.max / 10}
+                        step={50}
+                        value={clamp(parseNum(a.con), 0, ASSET_VAL_SLIDER.max / 10)}
+                        onChange={(e) => onUpdateAsset(asset, 'con', e.target.value)}
+                      />
+                      {conErr && <span className='field-error'>{conErr}</span>}
                     </div>
 
                     <div className='alloc-field'>
@@ -720,6 +805,7 @@ export function InputForm({
           {multiAssetMode && (
             <div className='alloc-summary'>
               <span>{tr(lang, 'form.assetAllocation.totalLabel')}: <strong>${Math.round(blendedCapital).toLocaleString()}</strong></span>
+              <span>{tr(lang, 'form.assetAllocation.totalContributionLabel')}: <strong>${Math.round(blendedContribution).toLocaleString()}/mo</strong></span>
               <span>{tr(lang, 'form.assetAllocation.blendedReturnLabel')}: <strong>{blendedReturnNum.toFixed(2)}%</strong></span>
               {mcMode && (
                 <span>{tr(lang, 'form.assetAllocation.blendedStdDevLabel')}: <strong>{blendedStdDevNum.toFixed(2)}%</strong></span>
@@ -727,14 +813,30 @@ export function InputForm({
             </div>
           )}
 
-          {/* Allocation bar (2+ active assets) */}
+          {/* Capital allocation bar */}
           {barSegments.length >= 2 && (
-            <AllocationBar
-              segments={barSegments}
-              onDragRebalance={handleDragRebalance}
-              onMoveLeft={handleMoveLeft}
-              onMoveRight={handleMoveRight}
-            />
+            <div className='alloc-bar-section'>
+              <span className='alloc-bar-title'>{tr(lang, 'form.assetAllocation.totalLabel')}</span>
+              <AllocationBar
+                segments={barSegments}
+                onDragRebalance={handleDragRebalance}
+                onMoveLeft={handleMoveLeft}
+                onMoveRight={handleMoveRight}
+              />
+            </div>
+          )}
+
+          {/* Monthly contribution bar */}
+          {conBarSegments.length >= 2 && (
+            <div className='alloc-bar-section'>
+              <span className='alloc-bar-title'>{tr(lang, 'form.assetAllocation.totalContributionLabel')}</span>
+              <AllocationBar
+                segments={conBarSegments}
+                onDragRebalance={handleConDragRebalance}
+                onMoveLeft={handleMoveLeft}
+                onMoveRight={handleMoveRight}
+              />
+            </div>
           )}
         </div>
       </details>

--- a/src/components/InputForm.tsx
+++ b/src/components/InputForm.tsx
@@ -72,6 +72,8 @@ interface InputFormProps {
   setStocksCon: (v: string) => void;
   allocOrder: string[];
   setAllocOrder: (v: string[]) => void;
+  stocksOn: boolean;
+  onToggleStocks: (on: boolean) => void;
   onToggleAsset: (asset: ExtraAsset, on: boolean) => void;
   onUpdateAsset: (asset: ExtraAsset, field: keyof ExtraAssetState, value: string | boolean) => void;
   cryptoClampNotice: boolean;
@@ -257,6 +259,8 @@ export function InputForm({
   setStocksCon,
   allocOrder,
   setAllocOrder,
+  stocksOn,
+  onToggleStocks,
   onToggleAsset,
   onUpdateAsset,
   cryptoClampNotice,
@@ -266,12 +270,14 @@ export function InputForm({
   const histMode = simMode === 'hist';
   const mcMode = simMode === 'mc';
 
+  const totalActive = (stocksOn ? 1 : 0) + EXTRA_ASSETS.filter((a) => extraAssets[a].on).length;
+
   const activeAssetKeys = allocOrder.filter(
-    (k) => k === 'stocks' || (EXTRA_ASSETS as readonly string[]).includes(k) && extraAssets[k as ExtraAsset].on,
+    (k) => (k === 'stocks' && stocksOn) || ((EXTRA_ASSETS as readonly string[]).includes(k) && extraAssets[k as ExtraAsset].on),
   );
 
-  const totalAllocVal = parseNum(stocksVal) + EXTRA_ASSETS.filter((a) => extraAssets[a].on).reduce((s, a) => s + parseNum(extraAssets[a].val), 0);
-  const totalAllocCon = parseNum(stocksCon) + EXTRA_ASSETS.filter((a) => extraAssets[a].on).reduce((s, a) => s + parseNum(extraAssets[a].con), 0);
+  const totalAllocVal = (stocksOn ? parseNum(stocksVal) : 0) + EXTRA_ASSETS.filter((a) => extraAssets[a].on).reduce((s, a) => s + parseNum(extraAssets[a].val), 0);
+  const totalAllocCon = (stocksOn ? parseNum(stocksCon) : 0) + EXTRA_ASSETS.filter((a) => extraAssets[a].on).reduce((s, a) => s + parseNum(extraAssets[a].con), 0);
 
   const barSegments: BarSegment[] = activeAssetKeys.length >= 2
     ? activeAssetKeys.map((k) => {
@@ -416,6 +422,28 @@ export function InputForm({
             {!histMode && errors.annualInflationPercent && (
               <span className='field-error'>{errors.annualInflationPercent}</span>
             )}
+            {mcMode && (
+              <>
+                <label className='field-sub-label' htmlFor='mcInflationStdDev'>{tr(lang, 'form.mc.inflationStdDev.label')}</label>
+                <input
+                  id='mcInflationStdDev'
+                  type='text'
+                  inputMode='decimal'
+                  value={mcInflationStdDev}
+                  onChange={(e) => setMcInflationStdDev(e.target.value)}
+                  className={errors.mcInflationStdDev ? 'input-error' : ''}
+                />
+                <input
+                  type='range'
+                  min={MC_SLIDERS.mcInflationStdDev.min}
+                  max={MC_SLIDERS.mcInflationStdDev.max}
+                  step={MC_SLIDERS.mcInflationStdDev.step}
+                  value={clamp(parseNum(mcInflationStdDev), MC_SLIDERS.mcInflationStdDev.min, MC_SLIDERS.mcInflationStdDev.max)}
+                  onChange={(e) => setMcInflationStdDev(e.target.value)}
+                />
+                {errors.mcInflationStdDev && <span className='field-error'>{errors.mcInflationStdDev}</span>}
+              </>
+            )}
           </div>
         </div>
 
@@ -476,209 +504,224 @@ export function InputForm({
         </div>
 
         <div className='alloc-body'>
-          {/* Stocks row — always shown */}
-          <div className='alloc-asset-row alloc-asset-row--stocks alloc-asset-row--on'>
-              <div className='alloc-asset-header'>
+          <div className='alloc-grid'>
+            {/* Stocks card */}
+            <div className={`alloc-card${stocksOn ? ' alloc-card--on' : ''}`}>
+              <div className='alloc-card-header'>
                 <span className='alloc-asset-swatch' style={{ background: ASSET_COLORS.stocks }} />
                 <span className='alloc-asset-name'>{tr(lang, 'form.assetAllocation.stocksLabel')}</span>
+                <button
+                  type='button'
+                  role='switch'
+                  aria-checked={stocksOn}
+                  className={`alloc-toggle${stocksOn ? ' alloc-toggle--on' : ''}`}
+                  disabled={stocksOn && totalActive === 1}
+                  onClick={() => onToggleStocks(!stocksOn)}
+                >
+                  <span className='alloc-toggle-thumb' />
+                </button>
               </div>
-              <div className='alloc-asset-fields'>
-                <div className='alloc-field'>
-                  <label className='alloc-field-label'>{tr(lang, 'form.assetAllocation.valueLabel')}</label>
-                  <input
-                    type='text'
-                    inputMode='decimal'
-                    value={stocksVal}
-                    onChange={(e) => setStocksVal(e.target.value)}
-                  />
-                  <input
-                    type='range'
-                    min={ASSET_VAL_SLIDER.min}
-                    max={ASSET_VAL_SLIDER.max}
-                    step={ASSET_VAL_SLIDER.step}
-                    value={clamp(parseNum(stocksVal), ASSET_VAL_SLIDER.min, ASSET_VAL_SLIDER.max)}
-                    onChange={(e) => setStocksVal(e.target.value)}
-                  />
-                </div>
-                <div className='alloc-field'>
-                  <label className='alloc-field-label'>{tr(lang, 'form.assetAllocation.contributionLabel')}</label>
-                  <input
-                    type='text'
-                    inputMode='decimal'
-                    value={stocksCon}
-                    onChange={(e) => setStocksCon(e.target.value)}
-                    className={errors.stocks_con ? 'input-error' : ''}
-                  />
-                  <input
-                    type='range'
-                    min={0}
-                    max={ASSET_VAL_SLIDER.max / 10}
-                    step={50}
-                    value={clamp(parseNum(stocksCon), 0, ASSET_VAL_SLIDER.max / 10)}
-                    onChange={(e) => setStocksCon(e.target.value)}
-                  />
-                  {errors.stocks_con && <span className='field-error'>{errors.stocks_con}</span>}
-                </div>
-                <div className='alloc-field'>
-                  <label className='alloc-field-label'>{tr(lang, 'form.assetAllocation.returnLabel')}</label>
-                  <input
-                    type='text'
-                    inputMode='decimal'
-                    value={annualReturnPercent}
-                    onChange={(e) => setAnnualReturnPercent(e.target.value)}
-                    disabled={histMode}
-                  />
-                  {!histMode && (
-                    <input
-                      type='range'
-                      min={ASSET_RETURN_SLIDER.min}
-                      max={ASSET_RETURN_SLIDER.max}
-                      step={ASSET_RETURN_SLIDER.step}
-                      value={clamp(parseNum(annualReturnPercent), ASSET_RETURN_SLIDER.min, ASSET_RETURN_SLIDER.max)}
-                      onChange={(e) => setAnnualReturnPercent(e.target.value)}
-                    />
-                  )}
-                </div>
-                {mcMode && (
+              {stocksOn && (
+                <div className='alloc-asset-fields'>
                   <div className='alloc-field'>
-                    <label className='alloc-field-label'>{tr(lang, 'form.assetAllocation.stdDevLabel')}</label>
+                    <label className='alloc-field-label'>{tr(lang, 'form.assetAllocation.valueLabel')}</label>
                     <input
                       type='text'
                       inputMode='decimal'
-                      value={mcReturnStdDev}
-                      onChange={(e) => setMcReturnStdDev(e.target.value)}
+                      value={stocksVal}
+                      onChange={(e) => setStocksVal(e.target.value)}
                     />
                     <input
                       type='range'
-                      min={MC_SLIDERS.mcReturnStdDev.min}
-                      max={MC_SLIDERS.mcReturnStdDev.max}
-                      step={MC_SLIDERS.mcReturnStdDev.step}
-                      value={clamp(parseNum(mcReturnStdDev), MC_SLIDERS.mcReturnStdDev.min, MC_SLIDERS.mcReturnStdDev.max)}
-                      onChange={(e) => setMcReturnStdDev(e.target.value)}
+                      min={ASSET_VAL_SLIDER.min}
+                      max={ASSET_VAL_SLIDER.max}
+                      step={ASSET_VAL_SLIDER.step}
+                      value={clamp(parseNum(stocksVal), ASSET_VAL_SLIDER.min, ASSET_VAL_SLIDER.max)}
+                      onChange={(e) => setStocksVal(e.target.value)}
                     />
                   </div>
-                )}
-              </div>
+                  <div className='alloc-field'>
+                    <label className='alloc-field-label'>{tr(lang, 'form.assetAllocation.contributionLabel')}</label>
+                    <input
+                      type='text'
+                      inputMode='decimal'
+                      value={stocksCon}
+                      onChange={(e) => setStocksCon(e.target.value)}
+                      className={errors.stocks_con ? 'input-error' : ''}
+                    />
+                    <input
+                      type='range'
+                      min={0}
+                      max={ASSET_VAL_SLIDER.max / 10}
+                      step={50}
+                      value={clamp(parseNum(stocksCon), 0, ASSET_VAL_SLIDER.max / 10)}
+                      onChange={(e) => setStocksCon(e.target.value)}
+                    />
+                    {errors.stocks_con && <span className='field-error'>{errors.stocks_con}</span>}
+                  </div>
+                  <div className='alloc-field'>
+                    <label className='alloc-field-label'>{tr(lang, 'form.assetAllocation.returnLabel')}</label>
+                    <input
+                      type='text'
+                      inputMode='decimal'
+                      value={annualReturnPercent}
+                      onChange={(e) => setAnnualReturnPercent(e.target.value)}
+                      disabled={histMode}
+                    />
+                    {!histMode && (
+                      <input
+                        type='range'
+                        min={ASSET_RETURN_SLIDER.min}
+                        max={ASSET_RETURN_SLIDER.max}
+                        step={ASSET_RETURN_SLIDER.step}
+                        value={clamp(parseNum(annualReturnPercent), ASSET_RETURN_SLIDER.min, ASSET_RETURN_SLIDER.max)}
+                        onChange={(e) => setAnnualReturnPercent(e.target.value)}
+                      />
+                    )}
+                  </div>
+                  {mcMode && (
+                    <div className='alloc-field'>
+                      <label className='alloc-field-label'>{tr(lang, 'form.assetAllocation.stdDevLabel')}</label>
+                      <input
+                        type='text'
+                        inputMode='decimal'
+                        value={mcReturnStdDev}
+                        onChange={(e) => setMcReturnStdDev(e.target.value)}
+                      />
+                      <input
+                        type='range'
+                        min={MC_SLIDERS.mcReturnStdDev.min}
+                        max={MC_SLIDERS.mcReturnStdDev.max}
+                        step={MC_SLIDERS.mcReturnStdDev.step}
+                        value={clamp(parseNum(mcReturnStdDev), MC_SLIDERS.mcReturnStdDev.min, MC_SLIDERS.mcReturnStdDev.max)}
+                        onChange={(e) => setMcReturnStdDev(e.target.value)}
+                      />
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
 
-          {/* Extra asset toggles */}
-          {EXTRA_ASSETS.map((asset) => {
-            const a = extraAssets[asset];
-            const label = tr(lang, ASSET_LABEL_KEYS[asset]);
-            const valErr = errors[`${asset}_val` as keyof AllErrors];
-            const conErr = errors[`${asset}_con` as keyof AllErrors];
-            const retErr = errors[`${asset}_ret` as keyof AllErrors];
-            const sdErr = errors[`${asset}_sd` as keyof AllErrors];
-            return (
-              <div key={asset} className={`alloc-asset-row${a.on ? ' alloc-asset-row--on' : ''}`}>
-                <div className='alloc-asset-header'>
-                  <span className='alloc-asset-swatch' style={{ background: ASSET_COLORS[asset] }} />
-                  <label className='alloc-toggle-label' htmlFor={`toggle-${asset}`}>
-                    {label}
-                  </label>
-                  <button
-                    id={`toggle-${asset}`}
-                    type='button'
-                    role='switch'
-                    aria-checked={a.on}
-                    className={`alloc-toggle${a.on ? ' alloc-toggle--on' : ''}`}
-                    onClick={() => onToggleAsset(asset, !a.on)}
-                  >
-                    <span className='alloc-toggle-thumb' />
-                  </button>
-                </div>
+            {/* Extra asset cards */}
+            {EXTRA_ASSETS.map((asset) => {
+              const a = extraAssets[asset];
+              const label = tr(lang, ASSET_LABEL_KEYS[asset]);
+              const valErr = errors[`${asset}_val` as keyof AllErrors];
+              const conErr = errors[`${asset}_con` as keyof AllErrors];
+              const retErr = errors[`${asset}_ret` as keyof AllErrors];
+              const sdErr = errors[`${asset}_sd` as keyof AllErrors];
+              return (
+                <div key={asset} className={`alloc-card${a.on ? ' alloc-card--on' : ''}`}>
+                  <div className='alloc-card-header'>
+                    <span className='alloc-asset-swatch' style={{ background: ASSET_COLORS[asset] }} />
+                    <label className='alloc-toggle-label' htmlFor={`toggle-${asset}`}>
+                      {label}
+                    </label>
+                    <button
+                      id={`toggle-${asset}`}
+                      type='button'
+                      role='switch'
+                      aria-checked={a.on}
+                      className={`alloc-toggle${a.on ? ' alloc-toggle--on' : ''}`}
+                      disabled={a.on && totalActive === 1}
+                      onClick={() => onToggleAsset(asset, !a.on)}
+                    >
+                      <span className='alloc-toggle-thumb' />
+                    </button>
+                  </div>
 
-                {a.on && (
-                  <div className='alloc-asset-fields'>
-                    <div className='alloc-field'>
-                      <label className='alloc-field-label'>{tr(lang, 'form.assetAllocation.valueLabel')}</label>
-                      <input
-                        type='text'
-                        inputMode='decimal'
-                        value={a.val}
-                        onChange={(e) => onUpdateAsset(asset, 'val', e.target.value)}
-                        className={valErr ? 'input-error' : ''}
-                      />
-                      <input
-                        type='range'
-                        min={ASSET_VAL_SLIDER.min}
-                        max={ASSET_VAL_SLIDER.max}
-                        step={ASSET_VAL_SLIDER.step}
-                        value={clamp(parseNum(a.val), ASSET_VAL_SLIDER.min, ASSET_VAL_SLIDER.max)}
-                        onChange={(e) => onUpdateAsset(asset, 'val', e.target.value)}
-                      />
-                      {valErr && <span className='field-error'>{valErr}</span>}
-                    </div>
-
-                    <div className='alloc-field'>
-                      <label className='alloc-field-label'>{tr(lang, 'form.assetAllocation.contributionLabel')}</label>
-                      <input
-                        type='text'
-                        inputMode='decimal'
-                        value={a.con}
-                        onChange={(e) => onUpdateAsset(asset, 'con', e.target.value)}
-                        className={conErr ? 'input-error' : ''}
-                      />
-                      <input
-                        type='range'
-                        min={0}
-                        max={ASSET_VAL_SLIDER.max / 10}
-                        step={50}
-                        value={clamp(parseNum(a.con), 0, ASSET_VAL_SLIDER.max / 10)}
-                        onChange={(e) => onUpdateAsset(asset, 'con', e.target.value)}
-                      />
-                      {conErr && <span className='field-error'>{conErr}</span>}
-                    </div>
-
-                    <div className='alloc-field'>
-                      <label className='alloc-field-label'>{tr(lang, 'form.assetAllocation.returnLabel')}</label>
-                      <input
-                        type='text'
-                        inputMode='decimal'
-                        value={a.ret}
-                        onChange={(e) => onUpdateAsset(asset, 'ret', e.target.value)}
-                        className={retErr ? 'input-error' : ''}
-                        disabled={histMode}
-                      />
-                      {!histMode && (
-                        <input
-                          type='range'
-                          min={ASSET_RETURN_SLIDER.min}
-                          max={ASSET_RETURN_SLIDER.max}
-                          step={ASSET_RETURN_SLIDER.step}
-                          value={clamp(parseNum(a.ret), ASSET_RETURN_SLIDER.min, ASSET_RETURN_SLIDER.max)}
-                          onChange={(e) => onUpdateAsset(asset, 'ret', e.target.value)}
-                        />
-                      )}
-                      {retErr && <span className='field-error'>{retErr}</span>}
-                    </div>
-
-                    {mcMode && (
+                  {a.on && (
+                    <div className='alloc-asset-fields'>
                       <div className='alloc-field'>
-                        <label className='alloc-field-label'>{tr(lang, 'form.assetAllocation.stdDevLabel')}</label>
+                        <label className='alloc-field-label'>{tr(lang, 'form.assetAllocation.valueLabel')}</label>
                         <input
                           type='text'
                           inputMode='decimal'
-                          value={a.sd}
-                          onChange={(e) => onUpdateAsset(asset, 'sd', e.target.value)}
-                          className={sdErr ? 'input-error' : ''}
+                          value={a.val}
+                          onChange={(e) => onUpdateAsset(asset, 'val', e.target.value)}
+                          className={valErr ? 'input-error' : ''}
                         />
                         <input
                           type='range'
-                          min={ASSET_SD_SLIDER.min}
-                          max={ASSET_SD_SLIDER.max}
-                          step={ASSET_SD_SLIDER.step}
-                          value={clamp(parseNum(a.sd), ASSET_SD_SLIDER.min, ASSET_SD_SLIDER.max)}
-                          onChange={(e) => onUpdateAsset(asset, 'sd', e.target.value)}
+                          min={ASSET_VAL_SLIDER.min}
+                          max={ASSET_VAL_SLIDER.max}
+                          step={ASSET_VAL_SLIDER.step}
+                          value={clamp(parseNum(a.val), ASSET_VAL_SLIDER.min, ASSET_VAL_SLIDER.max)}
+                          onChange={(e) => onUpdateAsset(asset, 'val', e.target.value)}
                         />
-                        {sdErr && <span className='field-error'>{sdErr}</span>}
+                        {valErr && <span className='field-error'>{valErr}</span>}
                       </div>
-                    )}
-                  </div>
-                )}
-              </div>
-            );
-          })}
+
+                      <div className='alloc-field'>
+                        <label className='alloc-field-label'>{tr(lang, 'form.assetAllocation.contributionLabel')}</label>
+                        <input
+                          type='text'
+                          inputMode='decimal'
+                          value={a.con}
+                          onChange={(e) => onUpdateAsset(asset, 'con', e.target.value)}
+                          className={conErr ? 'input-error' : ''}
+                        />
+                        <input
+                          type='range'
+                          min={0}
+                          max={ASSET_VAL_SLIDER.max / 10}
+                          step={50}
+                          value={clamp(parseNum(a.con), 0, ASSET_VAL_SLIDER.max / 10)}
+                          onChange={(e) => onUpdateAsset(asset, 'con', e.target.value)}
+                        />
+                        {conErr && <span className='field-error'>{conErr}</span>}
+                      </div>
+
+                      <div className='alloc-field'>
+                        <label className='alloc-field-label'>{tr(lang, 'form.assetAllocation.returnLabel')}</label>
+                        <input
+                          type='text'
+                          inputMode='decimal'
+                          value={a.ret}
+                          onChange={(e) => onUpdateAsset(asset, 'ret', e.target.value)}
+                          className={retErr ? 'input-error' : ''}
+                          disabled={histMode}
+                        />
+                        {!histMode && (
+                          <input
+                            type='range'
+                            min={ASSET_RETURN_SLIDER.min}
+                            max={ASSET_RETURN_SLIDER.max}
+                            step={ASSET_RETURN_SLIDER.step}
+                            value={clamp(parseNum(a.ret), ASSET_RETURN_SLIDER.min, ASSET_RETURN_SLIDER.max)}
+                            onChange={(e) => onUpdateAsset(asset, 'ret', e.target.value)}
+                          />
+                        )}
+                        {retErr && <span className='field-error'>{retErr}</span>}
+                      </div>
+
+                      {mcMode && (
+                        <div className='alloc-field'>
+                          <label className='alloc-field-label'>{tr(lang, 'form.assetAllocation.stdDevLabel')}</label>
+                          <input
+                            type='text'
+                            inputMode='decimal'
+                            value={a.sd}
+                            onChange={(e) => onUpdateAsset(asset, 'sd', e.target.value)}
+                            className={sdErr ? 'input-error' : ''}
+                          />
+                          <input
+                            type='range'
+                            min={ASSET_SD_SLIDER.min}
+                            max={ASSET_SD_SLIDER.max}
+                            step={ASSET_SD_SLIDER.step}
+                            value={clamp(parseNum(a.sd), ASSET_SD_SLIDER.min, ASSET_SD_SLIDER.max)}
+                            onChange={(e) => onUpdateAsset(asset, 'sd', e.target.value)}
+                          />
+                          {sdErr && <span className='field-error'>{sdErr}</span>}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
 
           {/* Crypto clamp notice */}
           {cryptoClampNotice && (
@@ -821,38 +864,6 @@ export function InputForm({
                     </option>
                   ))}
                 </select>
-              </div>
-            </div>
-
-            <div className='field'>
-              <label className='field-label' htmlFor='mcInflationStdDev'>
-                <span className='field-label-head'>
-                  <span className='field-label-text'>{tr(lang, 'form.mc.inflationStdDev.label')}</span>
-                  <FieldTooltip text={tr(lang, 'form.mc.inflationStdDev.tip')} />
-                </span>
-              </label>
-              <div className='field-control'>
-                <input
-                  id='mcInflationStdDev'
-                  type='text'
-                  inputMode='decimal'
-                  value={mcInflationStdDev}
-                  onChange={(e) => setMcInflationStdDev(e.target.value)}
-                  className={errors.mcInflationStdDev ? 'input-error' : ''}
-                />
-                <input
-                  type='range'
-                  min={MC_SLIDERS.mcInflationStdDev.min}
-                  max={MC_SLIDERS.mcInflationStdDev.max}
-                  step={MC_SLIDERS.mcInflationStdDev.step}
-                  value={clamp(
-                    parseNum(mcInflationStdDev),
-                    MC_SLIDERS.mcInflationStdDev.min,
-                    MC_SLIDERS.mcInflationStdDev.max,
-                  )}
-                  onChange={(e) => setMcInflationStdDev(e.target.value)}
-                />
-                {errors.mcInflationStdDev && <span className='field-error'>{errors.mcInflationStdDev}</span>}
               </div>
             </div>
           </div>

--- a/src/components/InputForm.tsx
+++ b/src/components/InputForm.tsx
@@ -1,7 +1,17 @@
+import { useRef, useCallback } from 'react';
 import { type Lang, tr, trParams } from '../i18n';
-import { SLIDERS, MC_RUN_COUNTS, HIST_FIRST_YEAR, HIST_LAST_YEAR, type FieldKey, type SimMode } from '../constants';
+import {
+  SLIDERS,
+  MC_RUN_COUNTS,
+  HIST_LAST_YEAR,
+  type SimMode,
+  EXTRA_ASSETS,
+  type ExtraAsset,
+  type ExtraAssetState,
+  ASSET_COLORS,
+} from '../constants';
 import { sliderVal, clamp, parseNum } from '../lib';
-import type { MCFieldKey } from '../lib';
+import type { AllErrors } from '../lib';
 import type { MCStatus } from '../App';
 import type { HistoricalRate } from '../data/historical';
 import { FieldTooltip } from './FieldTooltip';
@@ -11,9 +21,21 @@ const MC_SLIDERS = {
   mcInflationStdDev: { min: 0.5, max: 10, step: 0.5 },
 } as const;
 
+const ASSET_RETURN_SLIDER = { min: 0, max: 30, step: 0.5 };
+const ASSET_SD_SLIDER = { min: 0, max: 100, step: 1 };
+const ASSET_VAL_SLIDER = { min: 100, max: 200_000, step: 100 };
+
+const ASSET_LABEL_KEYS: Record<ExtraAsset, string> = {
+  bonds:      'form.assetAllocation.bondsLabel',
+  realestate: 'form.assetAllocation.realestateLabel',
+  gold:       'form.assetAllocation.goldLabel',
+  silver:     'form.assetAllocation.silverLabel',
+  crypto:     'form.assetAllocation.cryptoLabel',
+};
+
 interface InputFormProps {
   lang: Lang;
-  errors: Partial<Record<FieldKey | 'currentAge' | MCFieldKey, string>>;
+  errors: AllErrors;
   initialCapital: string;
   setInitialCapital: (v: string) => void;
   monthlyNeedToday: string;
@@ -32,6 +54,7 @@ interface InputFormProps {
   setSimMode: (v: SimMode) => void;
   histStartYear: number;
   setHistStartYear: (v: number) => void;
+  histMinYear: number;
   histData: HistoricalRate[] | null;
   histDataError: string | null;
   mcRunCount: string;
@@ -42,7 +65,161 @@ interface InputFormProps {
   setMcInflationStdDev: (v: string) => void;
   mcStatus: MCStatus;
   onRerunMC: () => void;
+  // multi-asset
+  multiAssetMode: boolean;
+  blendedCapital: number;
+  blendedReturnNum: number;
+  blendedStdDevNum: number;
+  extraAssets: Record<ExtraAsset, ExtraAssetState>;
+  stocksVal: string;
+  setStocksVal: (v: string) => void;
+  allocOrder: string[];
+  setAllocOrder: (v: string[]) => void;
+  onToggleAsset: (asset: ExtraAsset, on: boolean) => void;
+  onUpdateAsset: (asset: ExtraAsset, field: keyof ExtraAssetState, value: string | boolean) => void;
+  cryptoClampNotice: boolean;
+  onDismissCryptoClamp: () => void;
 }
+
+// ── Allocation Bar ────────────────────────────────────────────────────────────
+
+interface BarSegment {
+  key: string;
+  label: string;
+  color: string;
+  value: number;
+  pct: number;
+}
+
+interface AllocationBarProps {
+  segments: BarSegment[];
+  onDragRebalance: (leftKey: string, rightKey: string, deltaValue: number) => void;
+  onMoveLeft: (key: string) => void;
+  onMoveRight: (key: string) => void;
+}
+
+function AllocationBar({ segments, onDragRebalance, onMoveLeft, onMoveRight }: AllocationBarProps) {
+  const barRef = useRef<HTMLDivElement>(null);
+  const dragState = useRef<{
+    leftKey: string;
+    rightKey: string;
+    leftVal: number;
+    rightVal: number;
+    startX: number;
+    barWidth: number;
+    total: number;
+  } | null>(null);
+
+  const handleDividerPointerDown = useCallback(
+    (e: React.PointerEvent, leftKey: string, rightKey: string, leftVal: number, rightVal: number, total: number) => {
+      e.preventDefault();
+      const bar = barRef.current;
+      if (!bar) return;
+      (e.target as HTMLElement).setPointerCapture(e.pointerId);
+      dragState.current = {
+        leftKey,
+        rightKey,
+        leftVal,
+        rightVal,
+        startX: e.clientX,
+        barWidth: bar.getBoundingClientRect().width,
+        total,
+      };
+    },
+    [],
+  );
+
+  const handlePointerMove = useCallback((e: React.PointerEvent) => {
+    const ds = dragState.current;
+    if (!ds) return;
+    const dx = e.clientX - ds.startX;
+    const deltaValue = (dx / ds.barWidth) * ds.total;
+    const MIN = 100;
+    const clampedDelta = Math.max(-(ds.leftVal - MIN), Math.min(ds.rightVal - MIN, deltaValue));
+    onDragRebalance(ds.leftKey, ds.rightKey, clampedDelta);
+    // Update baseline so drag feels continuous
+    ds.leftVal += clampedDelta;
+    ds.rightVal -= clampedDelta;
+    ds.startX = e.clientX;
+  }, [onDragRebalance]);
+
+  const handlePointerUp = useCallback(() => {
+    dragState.current = null;
+  }, []);
+
+  const total = segments.reduce((s, seg) => s + seg.value, 0);
+
+  return (
+    <div
+      className='alloc-bar-wrap'
+      ref={barRef}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerUp}
+    >
+      <div className='alloc-bar'>
+        {segments.map((seg, i) => (
+          <div
+            key={seg.key}
+            className='alloc-bar-seg'
+            style={{ flex: `0 0 ${seg.pct}%`, background: seg.color }}
+          >
+            {seg.pct > 8 && (
+              <span className='alloc-bar-label'>
+                {seg.pct > 14 ? seg.label + ' ' : ''}{Math.round(seg.pct)}%
+              </span>
+            )}
+            {i < segments.length - 1 && (
+              <div
+                className='alloc-bar-divider'
+                onPointerDown={(e) =>
+                  handleDividerPointerDown(
+                    e,
+                    seg.key,
+                    segments[i + 1].key,
+                    seg.value,
+                    segments[i + 1].value,
+                    total,
+                  )
+                }
+              />
+            )}
+          </div>
+        ))}
+      </div>
+      <div className='alloc-bar-legend'>
+        {segments.map((seg, i) => (
+          <div key={seg.key} className='alloc-bar-legend-item'>
+            <span className='alloc-bar-legend-dot' style={{ background: seg.color }} />
+            <span className='alloc-bar-legend-name'>{seg.label}</span>
+            <div className='alloc-bar-legend-arrows'>
+              <button
+                type='button'
+                className='alloc-bar-arrow'
+                onClick={() => onMoveLeft(seg.key)}
+                disabled={i === 0}
+                aria-label={`Move ${seg.label} left`}
+              >
+                ←
+              </button>
+              <button
+                type='button'
+                className='alloc-bar-arrow'
+                onClick={() => onMoveRight(seg.key)}
+                disabled={i === segments.length - 1}
+                aria-label={`Move ${seg.label} right`}
+              >
+                →
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Main Form ─────────────────────────────────────────────────────────────────
 
 export function InputForm({
   lang,
@@ -65,6 +242,7 @@ export function InputForm({
   setSimMode,
   histStartYear,
   setHistStartYear,
+  histMinYear,
   histData,
   histDataError,
   mcRunCount,
@@ -75,15 +253,86 @@ export function InputForm({
   setMcInflationStdDev,
   mcStatus,
   onRerunMC,
+  multiAssetMode,
+  blendedCapital,
+  blendedReturnNum,
+  blendedStdDevNum,
+  extraAssets,
+  stocksVal,
+  setStocksVal,
+  allocOrder,
+  setAllocOrder,
+  onToggleAsset,
+  onUpdateAsset,
+  cryptoClampNotice,
+  onDismissCryptoClamp,
 }: InputFormProps) {
   const runsFormatted = Number(mcRunCount).toLocaleString();
   const histMode = simMode === 'hist';
+  const mcMode = simMode === 'mc';
+
+  // Build allocation bar segments
+  const activeAssetKeys = allocOrder.filter(
+    (k) => k === 'stocks' || (EXTRA_ASSETS as readonly string[]).includes(k) && extraAssets[k as ExtraAsset].on,
+  );
+
+  const totalAllocVal = multiAssetMode
+    ? parseNum(stocksVal) + EXTRA_ASSETS.filter((a) => extraAssets[a].on).reduce((s, a) => s + parseNum(extraAssets[a].val), 0)
+    : 0;
+
+  const barSegments: BarSegment[] = multiAssetMode && activeAssetKeys.length >= 2
+    ? activeAssetKeys.map((k) => {
+        const val = k === 'stocks' ? parseNum(stocksVal) : parseNum(extraAssets[k as ExtraAsset].val);
+        const pct = totalAllocVal > 0 ? (val / totalAllocVal) * 100 : 0;
+        const labelKey = k === 'stocks' ? 'form.assetAllocation.stocksLabel' : ASSET_LABEL_KEYS[k as ExtraAsset];
+        return { key: k, label: tr(lang, labelKey), color: ASSET_COLORS[k as import('../data/historical').AssetClass], value: val, pct };
+      })
+    : [];
+
+  function handleDragRebalance(leftKey: string, rightKey: string, deltaValue: number) {
+    const MIN = 100;
+    if (leftKey === 'stocks') {
+      const newLeft = Math.max(MIN, parseNum(stocksVal) + deltaValue);
+      const newRight = Math.max(MIN, parseNum(rightKey === 'stocks' ? stocksVal : extraAssets[rightKey as ExtraAsset].val) - deltaValue);
+      setStocksVal(String(Math.round(newLeft)));
+      if (rightKey !== 'stocks') onUpdateAsset(rightKey as ExtraAsset, 'val', String(Math.round(newRight)));
+    } else if (rightKey === 'stocks') {
+      const leftAsset = leftKey as ExtraAsset;
+      const newLeft = Math.max(MIN, parseNum(extraAssets[leftAsset].val) + deltaValue);
+      const newRight = Math.max(MIN, parseNum(stocksVal) - deltaValue);
+      onUpdateAsset(leftAsset, 'val', String(Math.round(newLeft)));
+      setStocksVal(String(Math.round(newRight)));
+    } else {
+      const leftAsset = leftKey as ExtraAsset;
+      const rightAsset = rightKey as ExtraAsset;
+      const newLeft = Math.max(MIN, parseNum(extraAssets[leftAsset].val) + deltaValue);
+      const newRight = Math.max(MIN, parseNum(extraAssets[rightAsset].val) - deltaValue);
+      onUpdateAsset(leftAsset, 'val', String(Math.round(newLeft)));
+      onUpdateAsset(rightAsset, 'val', String(Math.round(newRight)));
+    }
+  }
+
+  function handleMoveLeft(key: string) {
+    const idx = allocOrder.indexOf(key);
+    if (idx <= 0) return;
+    const next = [...allocOrder];
+    [next[idx - 1], next[idx]] = [next[idx], next[idx - 1]];
+    setAllocOrder(next);
+  }
+
+  function handleMoveRight(key: string) {
+    const idx = allocOrder.indexOf(key);
+    if (idx < 0 || idx >= allocOrder.length - 1) return;
+    const next = [...allocOrder];
+    [next[idx], next[idx + 1]] = [next[idx + 1], next[idx]];
+    setAllocOrder(next);
+  }
 
   return (
     <section className='panel form-panel'>
       <h2>{tr(lang, 'sections.params')}</h2>
       <div className='form-grid'>
-        <div className='field'>
+        <div className={`field${multiAssetMode ? ' field--readonly' : ''}`}>
           <label className='field-label' htmlFor='initialCapital'>
             <span className='field-label-head'>
               <span className='field-label-text'>{tr(lang, 'form.initialCapital.label')}</span>
@@ -95,11 +344,12 @@ export function InputForm({
               id='initialCapital'
               type='text'
               inputMode='decimal'
-              value={initialCapital}
-              onChange={(e) => setInitialCapital(e.target.value)}
-              className={errors.initialCapital ? 'input-error' : ''}
+              value={multiAssetMode ? String(Math.round(blendedCapital)) : initialCapital}
+              onChange={(e) => !multiAssetMode && setInitialCapital(e.target.value)}
+              readOnly={multiAssetMode}
+              className={!multiAssetMode && errors.initialCapital ? 'input-error' : ''}
             />
-            {errors.initialCapital && <span className='field-error'>{errors.initialCapital}</span>}
+            {!multiAssetMode && errors.initialCapital && <span className='field-error'>{errors.initialCapital}</span>}
           </div>
         </div>
 
@@ -193,7 +443,7 @@ export function InputForm({
           </div>
         </div>
 
-        <div className={`field${histMode ? ' field--disabled' : ''}`}>
+        <div className={`field${histMode || multiAssetMode ? ' field--disabled' : ''}`}>
           <label className='field-label' htmlFor='annualReturnPercent'>
             <span className='field-label-head'>
               <span className='field-label-text'>{tr(lang, 'form.return.label')}</span>
@@ -207,21 +457,24 @@ export function InputForm({
               id='annualReturnPercent'
               type='text'
               inputMode='decimal'
-              value={annualReturnPercent}
-              onChange={(e) => setAnnualReturnPercent(e.target.value)}
+              value={multiAssetMode ? blendedReturnNum.toFixed(2) : annualReturnPercent}
+              onChange={(e) => !multiAssetMode && !histMode && setAnnualReturnPercent(e.target.value)}
               disabled={histMode}
-              className={!histMode && errors.annualReturnPercent ? 'input-error' : ''}
+              readOnly={multiAssetMode}
+              className={!histMode && !multiAssetMode && errors.annualReturnPercent ? 'input-error' : ''}
             />
-            <input
-              type='range'
-              min={SLIDERS.annualReturnPercent.min}
-              max={SLIDERS.annualReturnPercent.max}
-              step={SLIDERS.annualReturnPercent.step}
-              value={sliderVal(annualReturnPercent, SLIDERS.annualReturnPercent)}
-              onChange={(e) => setAnnualReturnPercent(e.target.value)}
-              disabled={histMode}
-            />
-            {!histMode && errors.annualReturnPercent && (
+            {!multiAssetMode && (
+              <input
+                type='range'
+                min={SLIDERS.annualReturnPercent.min}
+                max={SLIDERS.annualReturnPercent.max}
+                step={SLIDERS.annualReturnPercent.step}
+                value={sliderVal(annualReturnPercent, SLIDERS.annualReturnPercent)}
+                onChange={(e) => setAnnualReturnPercent(e.target.value)}
+                disabled={histMode}
+              />
+            )}
+            {!histMode && !multiAssetMode && errors.annualReturnPercent && (
               <span className='field-error'>{errors.annualReturnPercent}</span>
             )}
           </div>
@@ -277,6 +530,215 @@ export function InputForm({
         </div>
       </div>
 
+      {/* ── Asset Allocation Section ── */}
+      <details className='alloc-section'>
+        <summary className='alloc-section-summary'>
+          {tr(lang, 'form.assetAllocation.sectionTitle')}
+          {multiAssetMode && (
+            <span className='alloc-section-badge'>
+              {EXTRA_ASSETS.filter((a) => extraAssets[a].on).length + 1}
+            </span>
+          )}
+        </summary>
+
+        <div className='alloc-body'>
+          {/* Stocks value row (shown when multi-asset) */}
+          {multiAssetMode && (
+            <div className='alloc-asset-row alloc-asset-row--stocks'>
+              <div className='alloc-asset-header'>
+                <span className='alloc-asset-swatch' style={{ background: ASSET_COLORS.stocks }} />
+                <span className='alloc-asset-name'>{tr(lang, 'form.assetAllocation.stocksLabel')}</span>
+              </div>
+              <div className='alloc-asset-fields'>
+                <div className='alloc-field'>
+                  <label className='alloc-field-label'>{tr(lang, 'form.assetAllocation.valueLabel')}</label>
+                  <input
+                    type='text'
+                    inputMode='decimal'
+                    value={stocksVal}
+                    onChange={(e) => setStocksVal(e.target.value)}
+                  />
+                  <input
+                    type='range'
+                    min={ASSET_VAL_SLIDER.min}
+                    max={ASSET_VAL_SLIDER.max}
+                    step={ASSET_VAL_SLIDER.step}
+                    value={clamp(parseNum(stocksVal), ASSET_VAL_SLIDER.min, ASSET_VAL_SLIDER.max)}
+                    onChange={(e) => setStocksVal(e.target.value)}
+                  />
+                </div>
+                <div className='alloc-field'>
+                  <label className='alloc-field-label'>{tr(lang, 'form.assetAllocation.returnLabel')}</label>
+                  <input
+                    type='text'
+                    inputMode='decimal'
+                    value={annualReturnPercent}
+                    onChange={(e) => setAnnualReturnPercent(e.target.value)}
+                    disabled={histMode}
+                  />
+                  {!histMode && (
+                    <input
+                      type='range'
+                      min={ASSET_RETURN_SLIDER.min}
+                      max={ASSET_RETURN_SLIDER.max}
+                      step={ASSET_RETURN_SLIDER.step}
+                      value={clamp(parseNum(annualReturnPercent), ASSET_RETURN_SLIDER.min, ASSET_RETURN_SLIDER.max)}
+                      onChange={(e) => setAnnualReturnPercent(e.target.value)}
+                    />
+                  )}
+                </div>
+                {mcMode && (
+                  <div className='alloc-field'>
+                    <label className='alloc-field-label'>{tr(lang, 'form.assetAllocation.stdDevLabel')}</label>
+                    <input
+                      type='text'
+                      inputMode='decimal'
+                      value={mcReturnStdDev}
+                      onChange={(e) => setMcReturnStdDev(e.target.value)}
+                    />
+                    <input
+                      type='range'
+                      min={MC_SLIDERS.mcReturnStdDev.min}
+                      max={MC_SLIDERS.mcReturnStdDev.max}
+                      step={MC_SLIDERS.mcReturnStdDev.step}
+                      value={clamp(parseNum(mcReturnStdDev), MC_SLIDERS.mcReturnStdDev.min, MC_SLIDERS.mcReturnStdDev.max)}
+                      onChange={(e) => setMcReturnStdDev(e.target.value)}
+                    />
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Extra asset toggles */}
+          {EXTRA_ASSETS.map((asset) => {
+            const a = extraAssets[asset];
+            const label = tr(lang, ASSET_LABEL_KEYS[asset]);
+            const valErr = errors[`${asset}_val` as keyof AllErrors];
+            const retErr = errors[`${asset}_ret` as keyof AllErrors];
+            const sdErr = errors[`${asset}_sd` as keyof AllErrors];
+            return (
+              <div key={asset} className={`alloc-asset-row${a.on ? ' alloc-asset-row--on' : ''}`}>
+                <div className='alloc-asset-header'>
+                  <span className='alloc-asset-swatch' style={{ background: ASSET_COLORS[asset] }} />
+                  <label className='alloc-toggle-label' htmlFor={`toggle-${asset}`}>
+                    {label}
+                  </label>
+                  <button
+                    id={`toggle-${asset}`}
+                    type='button'
+                    role='switch'
+                    aria-checked={a.on}
+                    className={`alloc-toggle${a.on ? ' alloc-toggle--on' : ''}`}
+                    onClick={() => onToggleAsset(asset, !a.on)}
+                  >
+                    <span className='alloc-toggle-thumb' />
+                  </button>
+                </div>
+
+                {a.on && (
+                  <div className='alloc-asset-fields'>
+                    <div className='alloc-field'>
+                      <label className='alloc-field-label'>{tr(lang, 'form.assetAllocation.valueLabel')}</label>
+                      <input
+                        type='text'
+                        inputMode='decimal'
+                        value={a.val}
+                        onChange={(e) => onUpdateAsset(asset, 'val', e.target.value)}
+                        className={valErr ? 'input-error' : ''}
+                      />
+                      <input
+                        type='range'
+                        min={ASSET_VAL_SLIDER.min}
+                        max={ASSET_VAL_SLIDER.max}
+                        step={ASSET_VAL_SLIDER.step}
+                        value={clamp(parseNum(a.val), ASSET_VAL_SLIDER.min, ASSET_VAL_SLIDER.max)}
+                        onChange={(e) => onUpdateAsset(asset, 'val', e.target.value)}
+                      />
+                      {valErr && <span className='field-error'>{valErr}</span>}
+                    </div>
+
+                    <div className='alloc-field'>
+                      <label className='alloc-field-label'>{tr(lang, 'form.assetAllocation.returnLabel')}</label>
+                      <input
+                        type='text'
+                        inputMode='decimal'
+                        value={a.ret}
+                        onChange={(e) => onUpdateAsset(asset, 'ret', e.target.value)}
+                        className={retErr ? 'input-error' : ''}
+                        disabled={histMode}
+                      />
+                      {!histMode && (
+                        <input
+                          type='range'
+                          min={ASSET_RETURN_SLIDER.min}
+                          max={ASSET_RETURN_SLIDER.max}
+                          step={ASSET_RETURN_SLIDER.step}
+                          value={clamp(parseNum(a.ret), ASSET_RETURN_SLIDER.min, ASSET_RETURN_SLIDER.max)}
+                          onChange={(e) => onUpdateAsset(asset, 'ret', e.target.value)}
+                        />
+                      )}
+                      {retErr && <span className='field-error'>{retErr}</span>}
+                    </div>
+
+                    {mcMode && (
+                      <div className='alloc-field'>
+                        <label className='alloc-field-label'>{tr(lang, 'form.assetAllocation.stdDevLabel')}</label>
+                        <input
+                          type='text'
+                          inputMode='decimal'
+                          value={a.sd}
+                          onChange={(e) => onUpdateAsset(asset, 'sd', e.target.value)}
+                          className={sdErr ? 'input-error' : ''}
+                        />
+                        <input
+                          type='range'
+                          min={ASSET_SD_SLIDER.min}
+                          max={ASSET_SD_SLIDER.max}
+                          step={ASSET_SD_SLIDER.step}
+                          value={clamp(parseNum(a.sd), ASSET_SD_SLIDER.min, ASSET_SD_SLIDER.max)}
+                          onChange={(e) => onUpdateAsset(asset, 'sd', e.target.value)}
+                        />
+                        {sdErr && <span className='field-error'>{sdErr}</span>}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+
+          {/* Crypto clamp notice */}
+          {cryptoClampNotice && (
+            <p className='alloc-notice'>
+              {trParams(lang, 'form.assetAllocation.cryptoYearClamp', { year: 2010 })}
+              <button type='button' className='alloc-notice-close' onClick={onDismissCryptoClamp}>×</button>
+            </p>
+          )}
+
+          {/* Blended summary */}
+          {multiAssetMode && (
+            <div className='alloc-summary'>
+              <span>{tr(lang, 'form.assetAllocation.totalLabel')}: <strong>${Math.round(blendedCapital).toLocaleString()}</strong></span>
+              <span>{tr(lang, 'form.assetAllocation.blendedReturnLabel')}: <strong>{blendedReturnNum.toFixed(2)}%</strong></span>
+              {mcMode && (
+                <span>{tr(lang, 'form.assetAllocation.blendedStdDevLabel')}: <strong>{blendedStdDevNum.toFixed(2)}%</strong></span>
+              )}
+            </div>
+          )}
+
+          {/* Allocation bar (2+ active assets) */}
+          {barSegments.length >= 2 && (
+            <AllocationBar
+              segments={barSegments}
+              onDragRebalance={handleDragRebalance}
+              onMoveLeft={handleMoveLeft}
+              onMoveRight={handleMoveRight}
+            />
+          )}
+        </div>
+      </details>
+
       <div className='sim-mode-section'>
         <span className='sim-mode-label'>{tr(lang, 'form.simMode.label')}</span>
         <div className='sim-mode-tabs' role='group' aria-label={tr(lang, 'form.simMode.label')}>
@@ -321,7 +783,7 @@ export function InputForm({
                   <FieldTooltip text={tr(lang, 'form.hist.startYearTip')} />
                 </span>
                 <span className='field-label-sub'>
-                  {trParams(lang, 'form.hist.dataRange', { first: HIST_FIRST_YEAR, last: HIST_LAST_YEAR })}
+                  {trParams(lang, 'form.hist.dataRange', { first: histMinYear, last: HIST_LAST_YEAR })}
                 </span>
               </label>
               <div className='field-control'>
@@ -332,12 +794,12 @@ export function InputForm({
                   value={histStartYear}
                   onChange={(e) => {
                     const v = parseInt(e.target.value, 10);
-                    if (v >= HIST_FIRST_YEAR && v <= HIST_LAST_YEAR) setHistStartYear(v);
+                    if (v >= histMinYear && v <= HIST_LAST_YEAR) setHistStartYear(v);
                   }}
                 />
                 <input
                   type='range'
-                  min={HIST_FIRST_YEAR}
+                  min={histMinYear}
                   max={HIST_LAST_YEAR}
                   step={1}
                   value={histStartYear}
@@ -375,7 +837,7 @@ export function InputForm({
               </div>
             </div>
 
-            <div className='field'>
+            <div className={`field${multiAssetMode ? ' field--readonly' : ''}`}>
               <label className='field-label' htmlFor='mcReturnStdDev'>
                 <span className='field-label-head'>
                   <span className='field-label-text'>{tr(lang, 'form.mc.returnStdDev.label')}</span>
@@ -387,19 +849,22 @@ export function InputForm({
                   id='mcReturnStdDev'
                   type='text'
                   inputMode='decimal'
-                  value={mcReturnStdDev}
-                  onChange={(e) => setMcReturnStdDev(e.target.value)}
-                  className={errors.mcReturnStdDev ? 'input-error' : ''}
+                  value={multiAssetMode ? blendedStdDevNum.toFixed(2) : mcReturnStdDev}
+                  onChange={(e) => !multiAssetMode && setMcReturnStdDev(e.target.value)}
+                  readOnly={multiAssetMode}
+                  className={!multiAssetMode && errors.mcReturnStdDev ? 'input-error' : ''}
                 />
-                <input
-                  type='range'
-                  min={MC_SLIDERS.mcReturnStdDev.min}
-                  max={MC_SLIDERS.mcReturnStdDev.max}
-                  step={MC_SLIDERS.mcReturnStdDev.step}
-                  value={clamp(parseNum(mcReturnStdDev), MC_SLIDERS.mcReturnStdDev.min, MC_SLIDERS.mcReturnStdDev.max)}
-                  onChange={(e) => setMcReturnStdDev(e.target.value)}
-                />
-                {errors.mcReturnStdDev && <span className='field-error'>{errors.mcReturnStdDev}</span>}
+                {!multiAssetMode && (
+                  <input
+                    type='range'
+                    min={MC_SLIDERS.mcReturnStdDev.min}
+                    max={MC_SLIDERS.mcReturnStdDev.max}
+                    step={MC_SLIDERS.mcReturnStdDev.step}
+                    value={clamp(parseNum(mcReturnStdDev), MC_SLIDERS.mcReturnStdDev.min, MC_SLIDERS.mcReturnStdDev.max)}
+                    onChange={(e) => setMcReturnStdDev(e.target.value)}
+                  />
+                )}
+                {!multiAssetMode && errors.mcReturnStdDev && <span className='field-error'>{errors.mcReturnStdDev}</span>}
               </div>
             </div>
 

--- a/src/components/InputForm.tsx
+++ b/src/components/InputForm.tsx
@@ -36,12 +36,8 @@ const ASSET_LABEL_KEYS: Record<ExtraAsset, string> = {
 interface InputFormProps {
   lang: Lang;
   errors: AllErrors;
-  initialCapital: string;
-  setInitialCapital: (v: string) => void;
   monthlyNeedToday: string;
   setMonthlyNeedToday: (v: string) => void;
-  monthlyContribution: string;
-  setMonthlyContribution: (v: string) => void;
   annualInflationPercent: string;
   setAnnualInflationPercent: (v: string) => void;
   annualReturnPercent: string;
@@ -65,8 +61,6 @@ interface InputFormProps {
   setMcInflationStdDev: (v: string) => void;
   mcStatus: MCStatus;
   onRerunMC: () => void;
-  // multi-asset
-  multiAssetMode: boolean;
   blendedCapital: number;
   blendedContribution: number;
   blendedReturnNum: number;
@@ -227,12 +221,8 @@ function AllocationBar({ segments, onDragRebalance, onMoveLeft, onMoveRight }: A
 export function InputForm({
   lang,
   errors,
-  initialCapital,
-  setInitialCapital,
   monthlyNeedToday,
   setMonthlyNeedToday,
-  monthlyContribution,
-  setMonthlyContribution,
   annualInflationPercent,
   setAnnualInflationPercent,
   annualReturnPercent,
@@ -256,7 +246,6 @@ export function InputForm({
   setMcInflationStdDev,
   mcStatus,
   onRerunMC,
-  multiAssetMode,
   blendedCapital,
   blendedContribution,
   blendedReturnNum,
@@ -277,20 +266,14 @@ export function InputForm({
   const histMode = simMode === 'hist';
   const mcMode = simMode === 'mc';
 
-  // Build allocation bar segments
   const activeAssetKeys = allocOrder.filter(
     (k) => k === 'stocks' || (EXTRA_ASSETS as readonly string[]).includes(k) && extraAssets[k as ExtraAsset].on,
   );
 
-  const totalAllocVal = multiAssetMode
-    ? parseNum(stocksVal) + EXTRA_ASSETS.filter((a) => extraAssets[a].on).reduce((s, a) => s + parseNum(extraAssets[a].val), 0)
-    : 0;
+  const totalAllocVal = parseNum(stocksVal) + EXTRA_ASSETS.filter((a) => extraAssets[a].on).reduce((s, a) => s + parseNum(extraAssets[a].val), 0);
+  const totalAllocCon = parseNum(stocksCon) + EXTRA_ASSETS.filter((a) => extraAssets[a].on).reduce((s, a) => s + parseNum(extraAssets[a].con), 0);
 
-  const totalAllocCon = multiAssetMode
-    ? parseNum(stocksCon) + EXTRA_ASSETS.filter((a) => extraAssets[a].on).reduce((s, a) => s + parseNum(extraAssets[a].con), 0)
-    : 0;
-
-  const barSegments: BarSegment[] = multiAssetMode && activeAssetKeys.length >= 2
+  const barSegments: BarSegment[] = activeAssetKeys.length >= 2
     ? activeAssetKeys.map((k) => {
         const val = k === 'stocks' ? parseNum(stocksVal) : parseNum(extraAssets[k as ExtraAsset].val);
         const pct = totalAllocVal > 0 ? (val / totalAllocVal) * 100 : 0;
@@ -299,7 +282,7 @@ export function InputForm({
       })
     : [];
 
-  const conBarSegments: BarSegment[] = multiAssetMode && activeAssetKeys.length >= 2 && totalAllocCon > 0
+  const conBarSegments: BarSegment[] = activeAssetKeys.length >= 2 && totalAllocCon > 0
     ? activeAssetKeys.map((k) => {
         const val = k === 'stocks' ? parseNum(stocksCon) : parseNum(extraAssets[k as ExtraAsset].con);
         const pct = totalAllocCon > 0 ? (val / totalAllocCon) * 100 : 0;
@@ -374,27 +357,6 @@ export function InputForm({
     <section className='panel form-panel'>
       <h2>{tr(lang, 'sections.params')}</h2>
       <div className='form-grid'>
-        <div className={`field${multiAssetMode ? ' field--readonly' : ''}`}>
-          <label className='field-label' htmlFor='initialCapital'>
-            <span className='field-label-head'>
-              <span className='field-label-text'>{tr(lang, 'form.initialCapital.label')}</span>
-              <FieldTooltip text={tr(lang, 'form.initialCapital.tip')} />
-            </span>
-          </label>
-          <div className='field-control'>
-            <input
-              id='initialCapital'
-              type='text'
-              inputMode='decimal'
-              value={multiAssetMode ? String(Math.round(blendedCapital)) : initialCapital}
-              onChange={(e) => !multiAssetMode && setInitialCapital(e.target.value)}
-              readOnly={multiAssetMode}
-              className={!multiAssetMode && errors.initialCapital ? 'input-error' : ''}
-            />
-            {!multiAssetMode && errors.initialCapital && <span className='field-error'>{errors.initialCapital}</span>}
-          </div>
-        </div>
-
         <div className='field'>
           <label className='field-label' htmlFor='monthlyNeedToday'>
             <span className='field-label-head'>
@@ -420,37 +382,6 @@ export function InputForm({
               onChange={(e) => setMonthlyNeedToday(e.target.value)}
             />
             {errors.monthlyNeedToday && <span className='field-error'>{errors.monthlyNeedToday}</span>}
-          </div>
-        </div>
-
-        <div className={`field${multiAssetMode ? ' field--readonly' : ''}`}>
-          <label className='field-label' htmlFor='monthlyContribution'>
-            <span className='field-label-head'>
-              <span className='field-label-text'>{tr(lang, 'form.monthlyContribution.label')}</span>
-              <FieldTooltip text={tr(lang, 'form.monthlyContribution.tip')} />
-            </span>
-          </label>
-          <div className='field-control'>
-            <input
-              id='monthlyContribution'
-              type='text'
-              inputMode='decimal'
-              value={multiAssetMode ? String(Math.round(blendedContribution)) : monthlyContribution}
-              onChange={(e) => !multiAssetMode && setMonthlyContribution(e.target.value)}
-              readOnly={multiAssetMode}
-              className={!multiAssetMode && errors.monthlyContribution ? 'input-error' : ''}
-            />
-            {!multiAssetMode && (
-              <input
-                type='range'
-                min={SLIDERS.monthlyContribution.min}
-                max={SLIDERS.monthlyContribution.max}
-                step={SLIDERS.monthlyContribution.step}
-                value={sliderVal(monthlyContribution, SLIDERS.monthlyContribution)}
-                onChange={(e) => setMonthlyContribution(e.target.value)}
-              />
-            )}
-            {!multiAssetMode && errors.monthlyContribution && <span className='field-error'>{errors.monthlyContribution}</span>}
           </div>
         </div>
 
@@ -484,43 +415,6 @@ export function InputForm({
             />
             {!histMode && errors.annualInflationPercent && (
               <span className='field-error'>{errors.annualInflationPercent}</span>
-            )}
-          </div>
-        </div>
-
-        <div className={`field${histMode || multiAssetMode ? ' field--disabled' : ''}`}>
-          <label className='field-label' htmlFor='annualReturnPercent'>
-            <span className='field-label-head'>
-              <span className='field-label-text'>{tr(lang, 'form.return.label')}</span>
-              <FieldTooltip
-                text={histMode ? tr(lang, 'form.hist.disabledReturnTip') : tr(lang, 'form.return.tip')}
-              />
-            </span>
-          </label>
-          <div className='field-control'>
-            <input
-              id='annualReturnPercent'
-              type='text'
-              inputMode='decimal'
-              value={multiAssetMode ? blendedReturnNum.toFixed(2) : annualReturnPercent}
-              onChange={(e) => !multiAssetMode && !histMode && setAnnualReturnPercent(e.target.value)}
-              disabled={histMode}
-              readOnly={multiAssetMode}
-              className={!histMode && !multiAssetMode && errors.annualReturnPercent ? 'input-error' : ''}
-            />
-            {!multiAssetMode && (
-              <input
-                type='range'
-                min={SLIDERS.annualReturnPercent.min}
-                max={SLIDERS.annualReturnPercent.max}
-                step={SLIDERS.annualReturnPercent.step}
-                value={sliderVal(annualReturnPercent, SLIDERS.annualReturnPercent)}
-                onChange={(e) => setAnnualReturnPercent(e.target.value)}
-                disabled={histMode}
-              />
-            )}
-            {!histMode && !multiAssetMode && errors.annualReturnPercent && (
-              <span className='field-error'>{errors.annualReturnPercent}</span>
             )}
           </div>
         </div>
@@ -576,20 +470,14 @@ export function InputForm({
       </div>
 
       {/* ── Asset Allocation Section ── */}
-      <details className='alloc-section'>
-        <summary className='alloc-section-summary'>
+      <div className='alloc-section'>
+        <div className='alloc-section-summary'>
           {tr(lang, 'form.assetAllocation.sectionTitle')}
-          {multiAssetMode && (
-            <span className='alloc-section-badge'>
-              {EXTRA_ASSETS.filter((a) => extraAssets[a].on).length + 1}
-            </span>
-          )}
-        </summary>
+        </div>
 
         <div className='alloc-body'>
-          {/* Stocks value row (shown when multi-asset) */}
-          {multiAssetMode && (
-            <div className='alloc-asset-row alloc-asset-row--stocks'>
+          {/* Stocks row — always shown */}
+          <div className='alloc-asset-row alloc-asset-row--stocks alloc-asset-row--on'>
               <div className='alloc-asset-header'>
                 <span className='alloc-asset-swatch' style={{ background: ASSET_COLORS.stocks }} />
                 <span className='alloc-asset-name'>{tr(lang, 'form.assetAllocation.stocksLabel')}</span>
@@ -672,7 +560,6 @@ export function InputForm({
                 )}
               </div>
             </div>
-          )}
 
           {/* Extra asset toggles */}
           {EXTRA_ASSETS.map((asset) => {
@@ -801,17 +688,15 @@ export function InputForm({
             </p>
           )}
 
-          {/* Blended summary */}
-          {multiAssetMode && (
-            <div className='alloc-summary'>
-              <span>{tr(lang, 'form.assetAllocation.totalLabel')}: <strong>${Math.round(blendedCapital).toLocaleString()}</strong></span>
-              <span>{tr(lang, 'form.assetAllocation.totalContributionLabel')}: <strong>${Math.round(blendedContribution).toLocaleString()}/mo</strong></span>
-              <span>{tr(lang, 'form.assetAllocation.blendedReturnLabel')}: <strong>{blendedReturnNum.toFixed(2)}%</strong></span>
-              {mcMode && (
-                <span>{tr(lang, 'form.assetAllocation.blendedStdDevLabel')}: <strong>{blendedStdDevNum.toFixed(2)}%</strong></span>
-              )}
-            </div>
-          )}
+          {/* Blended summary — always visible */}
+          <div className='alloc-summary'>
+            <span>{tr(lang, 'form.assetAllocation.totalLabel')}: <strong>${Math.round(blendedCapital).toLocaleString()}</strong></span>
+            <span>{tr(lang, 'form.assetAllocation.totalContributionLabel')}: <strong>${Math.round(blendedContribution).toLocaleString()}/mo</strong></span>
+            <span>{tr(lang, 'form.assetAllocation.blendedReturnLabel')}: <strong>{blendedReturnNum.toFixed(2)}%</strong></span>
+            {mcMode && (
+              <span>{tr(lang, 'form.assetAllocation.blendedStdDevLabel')}: <strong>{blendedStdDevNum.toFixed(2)}%</strong></span>
+            )}
+          </div>
 
           {/* Capital allocation bar */}
           {barSegments.length >= 2 && (
@@ -839,7 +724,7 @@ export function InputForm({
             </div>
           )}
         </div>
-      </details>
+      </div>
 
       <div className='sim-mode-section'>
         <span className='sim-mode-label'>{tr(lang, 'form.simMode.label')}</span>
@@ -936,37 +821,6 @@ export function InputForm({
                     </option>
                   ))}
                 </select>
-              </div>
-            </div>
-
-            <div className={`field${multiAssetMode ? ' field--readonly' : ''}`}>
-              <label className='field-label' htmlFor='mcReturnStdDev'>
-                <span className='field-label-head'>
-                  <span className='field-label-text'>{tr(lang, 'form.mc.returnStdDev.label')}</span>
-                  <FieldTooltip text={tr(lang, 'form.mc.returnStdDev.tip')} />
-                </span>
-              </label>
-              <div className='field-control'>
-                <input
-                  id='mcReturnStdDev'
-                  type='text'
-                  inputMode='decimal'
-                  value={multiAssetMode ? blendedStdDevNum.toFixed(2) : mcReturnStdDev}
-                  onChange={(e) => !multiAssetMode && setMcReturnStdDev(e.target.value)}
-                  readOnly={multiAssetMode}
-                  className={!multiAssetMode && errors.mcReturnStdDev ? 'input-error' : ''}
-                />
-                {!multiAssetMode && (
-                  <input
-                    type='range'
-                    min={MC_SLIDERS.mcReturnStdDev.min}
-                    max={MC_SLIDERS.mcReturnStdDev.max}
-                    step={MC_SLIDERS.mcReturnStdDev.step}
-                    value={clamp(parseNum(mcReturnStdDev), MC_SLIDERS.mcReturnStdDev.min, MC_SLIDERS.mcReturnStdDev.max)}
-                    onChange={(e) => setMcReturnStdDev(e.target.value)}
-                  />
-                )}
-                {!multiAssetMode && errors.mcReturnStdDev && <span className='field-error'>{errors.mcReturnStdDev}</span>}
               </div>
             </div>
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -64,7 +64,7 @@ export const QP = {
   // crypto
   crOn: 'crn', crVal: 'crv', crRet: 'crr', crSd: 'crd', crCon: 'crc',
   // stocks value and contribution in multi-asset mode
-  stV: 'stv', stCon: 'stc',
+  stV: 'stv', stCon: 'stc', stOn: 'sto',
   // allocation display order
   aOrd: 'aord',
 } as const;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -54,17 +54,17 @@ export const QP = {
   sm: 'sm',
   hy: 'hy',
   // bonds
-  bonOn: 'bon', bonVal: 'bov', bonRet: 'bor', bonSd: 'bod',
+  bonOn: 'bon', bonVal: 'bov', bonRet: 'bor', bonSd: 'bod', bonCon: 'boc',
   // realestate
-  reOn: 'reon', reVal: 'reov', reRet: 'reor', reSd: 'reod',
+  reOn: 'reon', reVal: 'reov', reRet: 'reor', reSd: 'reod', reCon: 'rec',
   // gold
-  goOn: 'gln', goVal: 'glv', goRet: 'glr', goSd: 'gld',
+  goOn: 'gln', goVal: 'glv', goRet: 'glr', goSd: 'gld', goCon: 'glc',
   // silver
-  siOn: 'svn', siVal: 'svv', siRet: 'svr', siSd: 'svd',
+  siOn: 'svn', siVal: 'svv', siRet: 'svr', siSd: 'svd', siCon: 'svc',
   // crypto
-  crOn: 'crn', crVal: 'crv', crRet: 'crr', crSd: 'crd',
-  // stocks value in multi-asset mode
-  stV: 'stv',
+  crOn: 'crn', crVal: 'crv', crRet: 'crr', crSd: 'crd', crCon: 'crc',
+  // stocks value and contribution in multi-asset mode
+  stV: 'stv', stCon: 'stc',
   // allocation display order
   aOrd: 'aord',
 } as const;
@@ -86,14 +86,15 @@ export type ExtraAssetState = {
   val: string;
   ret: string;
   sd: string;
+  con: string;
 };
 
 export const EXTRA_ASSET_DEFAULTS: Record<ExtraAsset, ExtraAssetState> = {
-  bonds:      { on: false, val: '5000',  ret: '4',  sd: '5'  },
-  realestate: { on: false, val: '5000',  ret: '6',  sd: '8'  },
-  gold:       { on: false, val: '2000',  ret: '5',  sd: '15' },
-  silver:     { on: false, val: '1000',  ret: '5',  sd: '25' },
-  crypto:     { on: false, val: '1000',  ret: '20', sd: '80' },
+  bonds:      { on: false, val: '5000',  ret: '4',  sd: '5',  con: '0' },
+  realestate: { on: false, val: '5000',  ret: '6',  sd: '8',  con: '0' },
+  gold:       { on: false, val: '2000',  ret: '5',  sd: '15', con: '0' },
+  silver:     { on: false, val: '1000',  ret: '5',  sd: '25', con: '0' },
+  crypto:     { on: false, val: '1000',  ret: '20', sd: '80', con: '0' },
 };
 
 export const ASSET_COLORS: Record<import('./data/historical').AssetClass, string> = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -53,6 +53,20 @@ export const QP = {
   mcis: 'mcis',
   sm: 'sm',
   hy: 'hy',
+  // bonds
+  bonOn: 'bon', bonVal: 'bov', bonRet: 'bor', bonSd: 'bod',
+  // realestate
+  reOn: 'reon', reVal: 'reov', reRet: 'reor', reSd: 'reod',
+  // gold
+  goOn: 'gln', goVal: 'glv', goRet: 'glr', goSd: 'gld',
+  // silver
+  siOn: 'svn', siVal: 'svv', siRet: 'svr', siSd: 'svd',
+  // crypto
+  crOn: 'crn', crVal: 'crv', crRet: 'crr', crSd: 'crd',
+  // stocks value in multi-asset mode
+  stV: 'stv',
+  // allocation display order
+  aOrd: 'aord',
 } as const;
 
 export const MC_DEFAULTS = {
@@ -63,3 +77,32 @@ export const MC_DEFAULTS = {
 };
 
 export const MC_RUN_COUNTS = ['500', '1000', '5000', '10000'] as const;
+
+export const EXTRA_ASSETS = ['bonds', 'realestate', 'gold', 'silver', 'crypto'] as const;
+export type ExtraAsset = (typeof EXTRA_ASSETS)[number];
+
+export type ExtraAssetState = {
+  on: boolean;
+  val: string;
+  ret: string;
+  sd: string;
+};
+
+export const EXTRA_ASSET_DEFAULTS: Record<ExtraAsset, ExtraAssetState> = {
+  bonds:      { on: false, val: '5000',  ret: '4',  sd: '5'  },
+  realestate: { on: false, val: '5000',  ret: '6',  sd: '8'  },
+  gold:       { on: false, val: '2000',  ret: '5',  sd: '15' },
+  silver:     { on: false, val: '1000',  ret: '5',  sd: '25' },
+  crypto:     { on: false, val: '1000',  ret: '20', sd: '80' },
+};
+
+export const ASSET_COLORS: Record<import('./data/historical').AssetClass, string> = {
+  stocks:     '#4e8ef7',
+  bonds:      '#4caf7d',
+  realestate: '#f0963a',
+  gold:       '#f5c518',
+  silver:     '#a0aec0',
+  crypto:     '#a78bfa',
+};
+
+export const DEFAULT_ALLOC_ORDER = ['stocks', 'bonds', 'realestate', 'gold', 'silver', 'crypto'];

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -52,6 +52,22 @@
       "disabledInflationTip": "Not used in historical mode — actual US CPI annual inflation data replaces this fixed rate.",
       "disabledReturnTip": "Not used in historical mode — actual S&P 500 annual returns replace this fixed rate."
     },
+    "assetAllocation": {
+      "sectionTitle": "Asset Allocation",
+      "stocksLabel": "Stocks / ETFs",
+      "bondsLabel": "Bonds",
+      "realestateLabel": "Real Estate",
+      "goldLabel": "Gold",
+      "silverLabel": "Silver",
+      "cryptoLabel": "Crypto",
+      "valueLabel": "Value ($)",
+      "returnLabel": "Annual Return (%)",
+      "stdDevLabel": "Std Dev (%)",
+      "cryptoYearClamp": "Start year clamped to {year} — earliest available crypto data.",
+      "totalLabel": "Total",
+      "blendedReturnLabel": "Blended return",
+      "blendedStdDevLabel": "Blended std dev"
+    },
     "mc": {
       "toggleLabel": "Monte Carlo mode",
       "toggleTip": "Runs many randomised scenarios to show a range of outcomes based on return and inflation volatility. The annual return and inflation are sampled from a normal distribution each year.",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -64,7 +64,9 @@
       "returnLabel": "Annual Return (%)",
       "stdDevLabel": "Std Dev (%)",
       "cryptoYearClamp": "Start year clamped to {year} — earliest available crypto data.",
+      "contributionLabel": "Monthly Contribution ($)",
       "totalLabel": "Total",
+      "totalContributionLabel": "Total monthly contribution",
       "blendedReturnLabel": "Blended return",
       "blendedStdDevLabel": "Blended std dev"
     },

--- a/src/i18n/sr.json
+++ b/src/i18n/sr.json
@@ -52,6 +52,22 @@
       "disabledInflationTip": "Ne koristi se u istorijskom modu — stvarna godišnja inflacija (američki CPI) zamenjuje ovu fiksnu stopu.",
       "disabledReturnTip": "Ne koristi se u istorijskom modu — stvarni godišnji prinosi S&P 500 zamenjuju ovu fiksnu stopu."
     },
+    "assetAllocation": {
+      "sectionTitle": "Raspodela imovine",
+      "stocksLabel": "Akcije / ETF",
+      "bondsLabel": "Obveznice",
+      "realestateLabel": "Nekretnine",
+      "goldLabel": "Zlato",
+      "silverLabel": "Srebro",
+      "cryptoLabel": "Kripto",
+      "valueLabel": "Vrednost ($)",
+      "returnLabel": "Godišnji prinos (%)",
+      "stdDevLabel": "Std. dev. (%)",
+      "cryptoYearClamp": "Početna godina ograničena na {year} — najstariji dostupni kripto podaci.",
+      "totalLabel": "Ukupno",
+      "blendedReturnLabel": "Mešoviti prinos",
+      "blendedStdDevLabel": "Mešovita std. dev."
+    },
     "mc": {
       "toggleLabel": "Monte Karlo mod",
       "toggleTip": "Pokreće mnogo nasumičnih scenarija kako bi prikazao opseg ishoda na osnovu promenljivosti prinosa i inflacije. Godišnji prinos i inflacija se uzorkuju iz normalne raspodele svake godine.",

--- a/src/i18n/sr.json
+++ b/src/i18n/sr.json
@@ -64,7 +64,9 @@
       "returnLabel": "Godišnji prinos (%)",
       "stdDevLabel": "Std. dev. (%)",
       "cryptoYearClamp": "Početna godina ograničena na {year} — najstariji dostupni kripto podaci.",
+      "contributionLabel": "Mesečni doprinos ($)",
       "totalLabel": "Ukupno",
+      "totalContributionLabel": "Ukupni mesečni doprinos",
       "blendedReturnLabel": "Mešoviti prinos",
       "blendedStdDevLabel": "Mešovita std. dev."
     },

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,5 +1,5 @@
 import { tr, type Lang } from './i18n';
-import { SLIDERS, type FieldKey } from './constants';
+import { SLIDERS, type FieldKey, type ExtraAsset, type ExtraAssetState, EXTRA_ASSETS } from './constants';
 
 export function parseNum(value: string): number {
   const n = Number.parseFloat(value.replace(',', '.'));
@@ -40,16 +40,26 @@ export function parseAgeYears(s: string): number | null {
 
 export type MCFieldKey = 'mcReturnStdDev' | 'mcInflationStdDev';
 
+export type AssetErrorKey =
+  | 'bonds_val' | 'bonds_ret' | 'bonds_sd'
+  | 'realestate_val' | 'realestate_ret' | 'realestate_sd'
+  | 'gold_val' | 'gold_ret' | 'gold_sd'
+  | 'silver_val' | 'silver_ret' | 'silver_sd'
+  | 'crypto_val' | 'crypto_ret' | 'crypto_sd';
+
+export type AllErrors = Partial<Record<FieldKey | 'currentAge' | MCFieldKey | AssetErrorKey, string>>;
+
 export function getErrors(
   vals: Record<FieldKey, string>,
   currentAge: string,
   lang: Lang,
   mcVals?: { mcReturnStdDev: string; mcInflationStdDev: string },
   histMode?: boolean,
-): Partial<Record<FieldKey | 'currentAge' | MCFieldKey, string>> {
-  const errors: Partial<Record<FieldKey | 'currentAge' | MCFieldKey, string>> = {};
+  allocVals?: { extraAssets: Record<ExtraAsset, ExtraAssetState>; mcMode?: boolean },
+): AllErrors {
+  const errors: AllErrors = {};
 
-  function check(key: FieldKey | MCFieldKey, val: string, opts: { min?: number; max?: number; nonNeg?: boolean } = {}) {
+  function check(key: keyof AllErrors, val: string, opts: { min?: number; max?: number; nonNeg?: boolean } = {}) {
     const n = parseNum(val);
     if (val.trim() === '' || !Number.isFinite(parseFloat(val.replace(',', '.')))) {
       errors[key] = tr(lang, 'errors.notNumber');
@@ -84,6 +94,18 @@ export function getErrors(
   if (mcVals) {
     check('mcReturnStdDev', mcVals.mcReturnStdDev, { nonNeg: true, max: 20 });
     check('mcInflationStdDev', mcVals.mcInflationStdDev, { nonNeg: true, max: 10 });
+  }
+
+  if (allocVals) {
+    for (const asset of EXTRA_ASSETS) {
+      const a = allocVals.extraAssets[asset];
+      if (!a.on) continue;
+      check(`${asset}_val` as AssetErrorKey, a.val, { min: 1 });
+      check(`${asset}_ret` as AssetErrorKey, a.ret, { min: 0, max: 100 });
+      if (allocVals.mcMode) {
+        check(`${asset}_sd` as AssetErrorKey, a.sd, { min: 0 });
+      }
+    }
   }
 
   return errors;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -41,11 +41,12 @@ export function parseAgeYears(s: string): number | null {
 export type MCFieldKey = 'mcReturnStdDev' | 'mcInflationStdDev';
 
 export type AssetErrorKey =
-  | 'bonds_val' | 'bonds_ret' | 'bonds_sd'
-  | 'realestate_val' | 'realestate_ret' | 'realestate_sd'
-  | 'gold_val' | 'gold_ret' | 'gold_sd'
-  | 'silver_val' | 'silver_ret' | 'silver_sd'
-  | 'crypto_val' | 'crypto_ret' | 'crypto_sd';
+  | 'bonds_val' | 'bonds_ret' | 'bonds_sd' | 'bonds_con'
+  | 'realestate_val' | 'realestate_ret' | 'realestate_sd' | 'realestate_con'
+  | 'gold_val' | 'gold_ret' | 'gold_sd' | 'gold_con'
+  | 'silver_val' | 'silver_ret' | 'silver_sd' | 'silver_con'
+  | 'crypto_val' | 'crypto_ret' | 'crypto_sd' | 'crypto_con'
+  | 'stocks_con';
 
 export type AllErrors = Partial<Record<FieldKey | 'currentAge' | MCFieldKey | AssetErrorKey, string>>;
 
@@ -55,7 +56,7 @@ export function getErrors(
   lang: Lang,
   mcVals?: { mcReturnStdDev: string; mcInflationStdDev: string },
   histMode?: boolean,
-  allocVals?: { extraAssets: Record<ExtraAsset, ExtraAssetState>; mcMode?: boolean },
+  allocVals?: { extraAssets: Record<ExtraAsset, ExtraAssetState>; stocksCon: string; mcMode?: boolean },
 ): AllErrors {
   const errors: AllErrors = {};
 
@@ -97,11 +98,13 @@ export function getErrors(
   }
 
   if (allocVals) {
+    check('stocks_con', allocVals.stocksCon, { nonNeg: true });
     for (const asset of EXTRA_ASSETS) {
       const a = allocVals.extraAssets[asset];
       if (!a.on) continue;
       check(`${asset}_val` as AssetErrorKey, a.val, { min: 1 });
       check(`${asset}_ret` as AssetErrorKey, a.ret, { min: 0, max: 100 });
+      check(`${asset}_con` as AssetErrorKey, a.con, { nonNeg: true });
       if (allocVals.mcMode) {
         check(`${asset}_sd` as AssetErrorKey, a.sd, { min: 0 });
       }

--- a/src/model/simulate.ts
+++ b/src/model/simulate.ts
@@ -1,3 +1,10 @@
+export type AssetAllocation = {
+  assetClass: import('../data/historical').AssetClass
+  value: number
+  annualReturnPercent: number
+  returnStdDevPercent: number
+}
+
 export type SimulationInput = {
   initialCapital: number
   monthlyNeedToday: number
@@ -5,6 +12,7 @@ export type SimulationInput = {
   monthlyContribution: number
   annualReturnPercent: number
   horizonYears: number
+  assetAllocations?: AssetAllocation[]
 }
 
 export type YearPoint = {
@@ -71,6 +79,8 @@ export function simulate(input: SimulationInput): SimulationResult {
 export function simulateHistorical(
   input: Omit<SimulationInput, 'annualReturnPercent' | 'annualInflationPercent'>,
   rates: { returnPct: number; inflationPct: number }[],
+  assetAllocations?: AssetAllocation[],
+  assetRates?: Partial<Record<Exclude<import('../data/historical').AssetClass, 'stocks'>, { returnPct: number }[]>>,
 ): SimulationResult {
   const monthlyNeed = input.monthlyNeedToday
   const contribYearly = 12 * input.monthlyContribution
@@ -81,8 +91,24 @@ export function simulateHistorical(
   let k = input.initialCapital
   let priceLevel = 1
 
+  const totalCapital = assetAllocations?.reduce((s, a) => s + a.value, 0) ?? k
+
   for (let y = 0; y <= effectiveH; y++) {
-    const r = rates[y].returnPct / 100
+    let returnPct: number
+    if (assetAllocations && assetRates && totalCapital > 0) {
+      returnPct = assetAllocations.reduce((sum, a) => {
+        const weight = a.value / totalCapital
+        if (a.assetClass === 'stocks') {
+          return sum + weight * rates[y].returnPct
+        }
+        const ar = assetRates[a.assetClass as Exclude<import('../data/historical').AssetClass, 'stocks'>]
+        return sum + weight * (ar?.[y]?.returnPct ?? a.annualReturnPercent)
+      }, 0)
+    } else {
+      returnPct = rates[y].returnPct
+    }
+
+    const r = returnPct / 100
     const annualExpenses = 12 * monthlyNeed * priceLevel
     const passiveReturn = k * r
 
@@ -163,6 +189,8 @@ export function simulateMonteCarlo(input: MonteCarloInput): MCResult {
   const returnStd = input.returnStdDevPercent / 100
   const inflationStd = input.inflationStdDevPercent / 100
   const contribYearly = 12 * input.monthlyContribution
+  const allocs = input.assetAllocations
+  const totalCapital = allocs ? allocs.reduce((s, a) => s + a.value, 0) : input.initialCapital
 
   for (let run = 0; run < N; run++) {
     let k = input.initialCapital
@@ -170,7 +198,16 @@ export function simulateMonteCarlo(input: MonteCarloInput): MCResult {
     let crossover: number | null = null
 
     for (let y = 0; y <= H; y++) {
-      const r = Math.max(0, baseR + (returnStd > 0 ? boxMuller() * returnStd : 0))
+      let r: number
+      if (allocs && totalCapital > 0) {
+        r = allocs.reduce((sum, a) => {
+          const weight = a.value / totalCapital
+          const draw = a.annualReturnPercent / 100 + (a.returnStdDevPercent > 0 ? boxMuller() * a.returnStdDevPercent / 100 : 0)
+          return sum + weight * Math.max(0, draw)
+        }, 0)
+      } else {
+        r = Math.max(0, baseR + (returnStd > 0 ? boxMuller() * returnStd : 0))
+      }
       const pi = basePi + (inflationStd > 0 ? boxMuller() * inflationStd : 0)
 
       const annualExpenses = 12 * input.monthlyNeedToday * priceLevel

--- a/src/url.ts
+++ b/src/url.ts
@@ -1,5 +1,24 @@
 import { type Lang } from './i18n';
-import { QP, type XMode, type SimMode, HIST_FIRST_YEAR, HIST_LAST_YEAR } from './constants';
+import {
+  QP,
+  type XMode,
+  type SimMode,
+  HIST_FIRST_YEAR,
+  HIST_LAST_YEAR,
+  EXTRA_ASSETS,
+  type ExtraAsset,
+  type ExtraAssetState,
+  EXTRA_ASSET_DEFAULTS,
+  DEFAULT_ALLOC_ORDER,
+} from './constants';
+
+const ASSET_QP: Record<ExtraAsset, { on: string; val: string; ret: string; sd: string }> = {
+  bonds:      { on: QP.bonOn, val: QP.bonVal, ret: QP.bonRet, sd: QP.bonSd },
+  realestate: { on: QP.reOn,  val: QP.reVal,  ret: QP.reRet,  sd: QP.reSd  },
+  gold:       { on: QP.goOn,  val: QP.goVal,  ret: QP.goRet,  sd: QP.goSd  },
+  silver:     { on: QP.siOn,  val: QP.siVal,  ret: QP.siRet,  sd: QP.siSd  },
+  crypto:     { on: QP.crOn,  val: QP.crVal,  ret: QP.crRet,  sd: QP.crSd  },
+};
 
 export function readUrlState(): {
   lang?: Lang;
@@ -16,6 +35,9 @@ export function readUrlState(): {
   mcReturnStdDev?: string;
   mcInflationStdDev?: string;
   histStartYear?: number;
+  stocksVal?: string;
+  extraAssets?: Record<ExtraAsset, ExtraAssetState>;
+  allocOrder?: string[];
 } {
   if (typeof window === 'undefined') return {};
   const sp = new URLSearchParams(window.location.search);
@@ -45,6 +67,35 @@ export function readUrlState(): {
     const hy = parseInt(hyv, 10);
     if (hy >= HIST_FIRST_YEAR && hy <= HIST_LAST_YEAR) o.histStartYear = hy;
   }
+
+  if (g(QP.stV) != null && g(QP.stV) !== '') o.stocksVal = g(QP.stV)!;
+
+  const extraAssets: Record<ExtraAsset, ExtraAssetState> = { ...EXTRA_ASSET_DEFAULTS };
+  let anyAssetInUrl = false;
+  for (const asset of EXTRA_ASSETS) {
+    const keys = ASSET_QP[asset];
+    const on = g(keys.on);
+    const val = g(keys.val);
+    const ret = g(keys.ret);
+    const sd = g(keys.sd);
+    if (on != null || val != null || ret != null || sd != null) {
+      anyAssetInUrl = true;
+      extraAssets[asset] = {
+        on: on === '1',
+        val: val ?? EXTRA_ASSET_DEFAULTS[asset].val,
+        ret: ret ?? EXTRA_ASSET_DEFAULTS[asset].ret,
+        sd: sd ?? EXTRA_ASSET_DEFAULTS[asset].sd,
+      };
+    }
+  }
+  if (anyAssetInUrl) o.extraAssets = extraAssets;
+
+  const aord = g(QP.aOrd);
+  if (aord) {
+    const parts = aord.split(',').filter(Boolean);
+    if (parts.length >= 1) o.allocOrder = parts;
+  }
+
   return o;
 }
 
@@ -63,6 +114,9 @@ export function buildSearchParams(state: {
   mcReturnStdDev: string;
   mcInflationStdDev: string;
   histStartYear: number;
+  stocksVal: string;
+  extraAssets: Record<ExtraAsset, ExtraAssetState>;
+  allocOrder: string[];
 }): string {
   const sp = new URLSearchParams();
   sp.set(QP.l, state.lang);
@@ -83,5 +137,25 @@ export function buildSearchParams(state: {
     sp.set(QP.sm, 'hist');
     sp.set(QP.hy, String(state.histStartYear));
   }
+
+  const anyOn = EXTRA_ASSETS.some((a) => state.extraAssets[a].on);
+  if (anyOn) {
+    sp.set(QP.stV, state.stocksVal);
+    for (const asset of EXTRA_ASSETS) {
+      const a = state.extraAssets[asset];
+      const keys = ASSET_QP[asset];
+      sp.set(keys.on, a.on ? '1' : '0');
+      if (a.on) {
+        sp.set(keys.val, a.val);
+        sp.set(keys.ret, a.ret);
+        sp.set(keys.sd, a.sd);
+      }
+    }
+    const order = state.allocOrder.join(',');
+    if (order !== DEFAULT_ALLOC_ORDER.join(',')) {
+      sp.set(QP.aOrd, order);
+    }
+  }
+
   return sp.toString();
 }

--- a/src/url.ts
+++ b/src/url.ts
@@ -12,12 +12,12 @@ import {
   DEFAULT_ALLOC_ORDER,
 } from './constants';
 
-const ASSET_QP: Record<ExtraAsset, { on: string; val: string; ret: string; sd: string }> = {
-  bonds:      { on: QP.bonOn, val: QP.bonVal, ret: QP.bonRet, sd: QP.bonSd },
-  realestate: { on: QP.reOn,  val: QP.reVal,  ret: QP.reRet,  sd: QP.reSd  },
-  gold:       { on: QP.goOn,  val: QP.goVal,  ret: QP.goRet,  sd: QP.goSd  },
-  silver:     { on: QP.siOn,  val: QP.siVal,  ret: QP.siRet,  sd: QP.siSd  },
-  crypto:     { on: QP.crOn,  val: QP.crVal,  ret: QP.crRet,  sd: QP.crSd  },
+const ASSET_QP: Record<ExtraAsset, { on: string; val: string; ret: string; sd: string; con: string }> = {
+  bonds:      { on: QP.bonOn, val: QP.bonVal, ret: QP.bonRet, sd: QP.bonSd, con: QP.bonCon },
+  realestate: { on: QP.reOn,  val: QP.reVal,  ret: QP.reRet,  sd: QP.reSd,  con: QP.reCon  },
+  gold:       { on: QP.goOn,  val: QP.goVal,  ret: QP.goRet,  sd: QP.goSd,  con: QP.goCon  },
+  silver:     { on: QP.siOn,  val: QP.siVal,  ret: QP.siRet,  sd: QP.siSd,  con: QP.siCon  },
+  crypto:     { on: QP.crOn,  val: QP.crVal,  ret: QP.crRet,  sd: QP.crSd,  con: QP.crCon  },
 };
 
 export function readUrlState(): {
@@ -36,6 +36,7 @@ export function readUrlState(): {
   mcInflationStdDev?: string;
   histStartYear?: number;
   stocksVal?: string;
+  stocksCon?: string;
   extraAssets?: Record<ExtraAsset, ExtraAssetState>;
   allocOrder?: string[];
 } {
@@ -69,8 +70,15 @@ export function readUrlState(): {
   }
 
   if (g(QP.stV) != null && g(QP.stV) !== '') o.stocksVal = g(QP.stV)!;
+  if (g(QP.stCon) != null && g(QP.stCon) !== '') o.stocksCon = g(QP.stCon)!;
 
-  const extraAssets: Record<ExtraAsset, ExtraAssetState> = { ...EXTRA_ASSET_DEFAULTS };
+  const extraAssets: Record<ExtraAsset, ExtraAssetState> = {
+    bonds:      { ...EXTRA_ASSET_DEFAULTS.bonds      },
+    realestate: { ...EXTRA_ASSET_DEFAULTS.realestate },
+    gold:       { ...EXTRA_ASSET_DEFAULTS.gold       },
+    silver:     { ...EXTRA_ASSET_DEFAULTS.silver     },
+    crypto:     { ...EXTRA_ASSET_DEFAULTS.crypto     },
+  };
   let anyAssetInUrl = false;
   for (const asset of EXTRA_ASSETS) {
     const keys = ASSET_QP[asset];
@@ -78,13 +86,15 @@ export function readUrlState(): {
     const val = g(keys.val);
     const ret = g(keys.ret);
     const sd = g(keys.sd);
-    if (on != null || val != null || ret != null || sd != null) {
+    const con = g(keys.con);
+    if (on != null || val != null || ret != null || sd != null || con != null) {
       anyAssetInUrl = true;
       extraAssets[asset] = {
         on: on === '1',
         val: val ?? EXTRA_ASSET_DEFAULTS[asset].val,
         ret: ret ?? EXTRA_ASSET_DEFAULTS[asset].ret,
-        sd: sd ?? EXTRA_ASSET_DEFAULTS[asset].sd,
+        sd:  sd  ?? EXTRA_ASSET_DEFAULTS[asset].sd,
+        con: con ?? EXTRA_ASSET_DEFAULTS[asset].con,
       };
     }
   }
@@ -115,6 +125,7 @@ export function buildSearchParams(state: {
   mcInflationStdDev: string;
   histStartYear: number;
   stocksVal: string;
+  stocksCon: string;
   extraAssets: Record<ExtraAsset, ExtraAssetState>;
   allocOrder: string[];
 }): string {
@@ -141,6 +152,7 @@ export function buildSearchParams(state: {
   const anyOn = EXTRA_ASSETS.some((a) => state.extraAssets[a].on);
   if (anyOn) {
     sp.set(QP.stV, state.stocksVal);
+    sp.set(QP.stCon, state.stocksCon);
     for (const asset of EXTRA_ASSETS) {
       const a = state.extraAssets[asset];
       const keys = ASSET_QP[asset];
@@ -149,6 +161,7 @@ export function buildSearchParams(state: {
         sp.set(keys.val, a.val);
         sp.set(keys.ret, a.ret);
         sp.set(keys.sd, a.sd);
+        sp.set(keys.con, a.con);
       }
     }
     const order = state.allocOrder.join(',');

--- a/src/url.ts
+++ b/src/url.ts
@@ -35,6 +35,7 @@ export function readUrlState(): {
   mcReturnStdDev?: string;
   mcInflationStdDev?: string;
   histStartYear?: number;
+  stocksOn?: boolean;
   stocksVal?: string;
   stocksCon?: string;
   extraAssets?: Record<ExtraAsset, ExtraAssetState>;
@@ -69,6 +70,7 @@ export function readUrlState(): {
     if (hy >= HIST_FIRST_YEAR && hy <= HIST_LAST_YEAR) o.histStartYear = hy;
   }
 
+  if (g(QP.stOn) === '0') o.stocksOn = false;
   if (g(QP.stV) != null && g(QP.stV) !== '') o.stocksVal = g(QP.stV)!;
   if (g(QP.stCon) != null && g(QP.stCon) !== '') o.stocksCon = g(QP.stCon)!;
 
@@ -122,6 +124,7 @@ export function buildSearchParams(state: {
   mcReturnStdDev: string;
   mcInflationStdDev: string;
   histStartYear: number;
+  stocksOn: boolean;
   stocksVal: string;
   stocksCon: string;
   extraAssets: Record<ExtraAsset, ExtraAssetState>;
@@ -145,6 +148,7 @@ export function buildSearchParams(state: {
     sp.set(QP.hy, String(state.histStartYear));
   }
 
+  if (!state.stocksOn) sp.set(QP.stOn, '0');
   sp.set(QP.stV, state.stocksVal);
   sp.set(QP.stCon, state.stocksCon);
   for (const asset of EXTRA_ASSETS) {

--- a/src/url.ts
+++ b/src/url.ts
@@ -111,10 +111,8 @@ export function readUrlState(): {
 
 export function buildSearchParams(state: {
   lang: Lang;
-  initialCapital: string;
   monthlyNeedToday: string;
   annualInflationPercent: string;
-  monthlyContribution: string;
   annualReturnPercent: string;
   horizonYears: string;
   currentAge: string;
@@ -131,10 +129,8 @@ export function buildSearchParams(state: {
 }): string {
   const sp = new URLSearchParams();
   sp.set(QP.l, state.lang);
-  sp.set(QP.ic, state.initialCapital);
   sp.set(QP.mn, state.monthlyNeedToday);
   sp.set(QP.inf, state.annualInflationPercent);
-  sp.set(QP.mc, state.monthlyContribution);
   sp.set(QP.ar, state.annualReturnPercent);
   sp.set(QP.h, state.horizonYears);
   if (state.currentAge.trim() !== '') sp.set(QP.a, state.currentAge);
@@ -149,25 +145,22 @@ export function buildSearchParams(state: {
     sp.set(QP.hy, String(state.histStartYear));
   }
 
-  const anyOn = EXTRA_ASSETS.some((a) => state.extraAssets[a].on);
-  if (anyOn) {
-    sp.set(QP.stV, state.stocksVal);
-    sp.set(QP.stCon, state.stocksCon);
-    for (const asset of EXTRA_ASSETS) {
-      const a = state.extraAssets[asset];
-      const keys = ASSET_QP[asset];
-      sp.set(keys.on, a.on ? '1' : '0');
-      if (a.on) {
-        sp.set(keys.val, a.val);
-        sp.set(keys.ret, a.ret);
-        sp.set(keys.sd, a.sd);
-        sp.set(keys.con, a.con);
-      }
+  sp.set(QP.stV, state.stocksVal);
+  sp.set(QP.stCon, state.stocksCon);
+  for (const asset of EXTRA_ASSETS) {
+    const a = state.extraAssets[asset];
+    const keys = ASSET_QP[asset];
+    sp.set(keys.on, a.on ? '1' : '0');
+    if (a.on) {
+      sp.set(keys.val, a.val);
+      sp.set(keys.ret, a.ret);
+      sp.set(keys.sd, a.sd);
+      sp.set(keys.con, a.con);
     }
-    const order = state.allocOrder.join(',');
-    if (order !== DEFAULT_ALLOC_ORDER.join(',')) {
-      sp.set(QP.aOrd, order);
-    }
+  }
+  const order = state.allocOrder.join(',');
+  if (order !== DEFAULT_ALLOC_ORDER.join(',')) {
+    sp.set(QP.aOrd, order);
   }
 
   return sp.toString();


### PR DESCRIPTION
## Summary

- Adds 5 toggle switches (Bonds, Real Estate, Gold, Silver, Crypto) in a collapsible **Asset Allocation** section below the main form fields
- When any extra asset is toggled on, `initialCapital` and `annualReturnPercent` fields become read-only and display computed blended values; a **Stocks / ETFs value** input appears
- Each active asset has its own **Value**, **Annual Return %**, and (MC mode only) **Std Dev %** inputs with sliders
- A segmented, draggable **allocation bar** appears when 2+ assets are active — dragging a divider redistributes adjacent values in real-time (minimum $100 per segment enforced); ← → buttons reorder segments cosmetically
- Fixed mode: blended return computed before calling `simulate()`
- MC mode: per-asset random draws weighted by allocation value
- Historical mode: per-asset rate arrays fetched and blended per year
- Crypto enabled: `histStartYear` slider minimum clamped to 2010 with dismissable notice
- All allocation state persisted in URL query params
- Per-asset validation errors (value > 0, return 0–100, std dev ≥ 0)
- EN and SR translations for all new text

## Test plan
- [ ] Toggle each of the 5 asset classes on/off; verify input groups appear/disappear
- [ ] Verify `initialCapital` becomes read-only sum and `annualReturnPercent` becomes read-only blended value when any extra asset is on
- [ ] Switch to MC mode; verify Std Dev inputs appear and the top-level MC return std dev becomes read-only (showing portfolio-weighted value)
- [ ] Drag a divider on the allocation bar; verify adjacent values change in real-time and total stays constant
- [ ] Try to drag a segment below $100; verify it is clamped
- [ ] Use ← → arrows to reorder segments; verify it only changes visual order, not values
- [ ] Enable Crypto; verify start year slider min jumps to 2010 and the notice appears
- [ ] Verify all state round-trips through the URL (share a link and reload)
- [ ] Switch to Historical mode; verify blended multi-asset historical simulation runs
- [ ] Verify TypeScript build passes with no errors

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)